### PR TITLE
Use custom useQuery and useMutation hooks in TreeData and children

### DIFF
--- a/client/src/api/apiUtils.js
+++ b/client/src/api/apiUtils.js
@@ -29,11 +29,15 @@ function createAPIFetch(method) {
         url += `?${paramString}`;
       }
     } else {
-      url = apiEndpoints[query];
+      const [api, body] = Array.isArray(query)
+        ? query
+        : [query, data];
+
+      url = apiEndpoints[api];
       Object.assign(options, defaultPostOptions);
 
-      if (data) {
-        options.body = JSON.stringify(data);
+      if (body) {
+        options.body = JSON.stringify(body);
       }
     }
 

--- a/client/src/api/queries.js
+++ b/client/src/api/queries.js
@@ -9,22 +9,33 @@ function createUseQuery(api, defaultData = {}) {
   };
 }
 
-function createUseMutation(...apis) {
+function createUseMutation(apiList, method = 'POST') {
+  const apis = Array.isArray(apiList)
+    ? apiList
+    : [apiList];
+  const apiCaller = method === 'POST'
+    ? postData
+    : putData;
+
   return function() {
     const queryClient = useQueryClient();
 
-    return useMutation(([data]) => postData(apis[0], data), {
+    return useMutation(data => apiCaller(apis[0], data), {
       onSuccess: () => apis.forEach(api => queryClient.invalidateQueries(api)),
-      onError: console.error,
+      onError: error => console.error(`useMutation: ${method} ${apis} ${error}`),
     });
   };
 }
 
 export const useCitiesQuery = createUseQuery('cities');
 export const useCountriesQuery = createUseQuery('countries', { country: 'All' });
+export const useTreeQuery = createUseQuery('trees');
+export const useTreeHistoryQuery = createUseQuery('treehistory');
 
-//const useLikesMutation = createUseMutation('treelikes', 'treehistory');
-//const useAdoptionMutation = createUseMutation('treeadoptions', 'treehistory');
+export const useTreeDataMutation = createUseMutation(['trees', 'treemap'], 'PUT');
+export const useTreeHistoryMutation = createUseMutation('treehistory');
+//const useTreeLikesMutation = createUseMutation(['treelikes', 'treehistory']);
+//const useTreeAdoptionsMutation = createUseMutation(['treeadoptions', 'treehistory']);
 
 // TODO: remove this export when everything is using a custom hook
 export { getData, postData, putData };

--- a/client/src/pages/treedata/TreeAdoptionLike.js
+++ b/client/src/pages/treedata/TreeAdoptionLike.js
@@ -88,7 +88,7 @@ export default function AdoptLikeCheckboxes({ idTree, common, mutateHistory }) {
       mutateTreeLikes.mutate(['treelikes', sendTreeUser]);
     }
 
-    mutateHistory.mutate(['treehistory', sendTreeHistory]);
+    mutateHistory.mutate(sendTreeHistory);
   };
 
   if (!user) return null;

--- a/client/src/pages/treedata/TreeDataEdit.js
+++ b/client/src/pages/treedata/TreeDataEdit.js
@@ -54,7 +54,7 @@ export default function TreeHeaderForm({
     if (sendDataFiltered.common !== common
        || sendDataFiltered.scientific !== scientific
        || sendDataFiltered.genus !== genus) {
-      mutateTreeData.mutate(['trees', sendDataFiltered]);
+      mutateTreeData.mutate(sendDataFiltered);
     }
 
     // new history
@@ -70,7 +70,7 @@ export default function TreeHeaderForm({
     };
 
     if (!lowercaseCommon.includes('vacant')) {
-      mutateHistory.mutate(['treehistory', sendTreeHistory]);
+      mutateHistory.mutate(sendTreeHistory);
     }
 
     setEditTree(false);

--- a/client/src/pages/treedata/TreeHealth.js
+++ b/client/src/pages/treedata/TreeHealth.js
@@ -24,7 +24,7 @@ export default function TreeHealthSlider({
         // purely DOM marker so vectortiles don't need to rewrite until browser reload
       addNewMarker(newHealth, lng, lat, map);
 
-      mutateTreeData.mutate(['trees', sendTreeData]);
+      mutateTreeData.mutate(sendTreeData);
       setTimeout(() => setHealthSaveAlert(''), saveTimer);
     }
     return newHealth;

--- a/client/src/pages/treedata/TreeRemoval.js
+++ b/client/src/pages/treedata/TreeRemoval.js
@@ -63,8 +63,8 @@ export default function TreeRemoval({
 
       setMessage(`Removing ${common}.`);
 
-      mutateHistory.mutate(['treehistory', sendTreeHistory]);
-      mutateTreeData.mutate(['trees', sendTreeData]);
+      mutateHistory.mutate(sendTreeHistory);
+      mutateTreeData.mutate(sendTreeData);
       setReallyDelete(false);
       setShowDelete(false);
       setMessage('');


### PR DESCRIPTION
- Support creating useMutation hooks that use either POST or PUT, and can pass in either one string or an array.
- Create useTreeDataMutation and useTreeHistoryMutation hooks.
- Fix createAPIFetch() to handle query and data being passed in an array, as they are currently when getPost() is used directly.
- Return early with null if there's no treeData, instead of having everything hang off of a check on idTree.
- Arrange props in consistent order.

**Question**: the mutation hooks aren't actually used in `<TreeData>`.  They're just passed as props to its children.  If the mutation hooks are now created in just one place (`api/queries.js`), would it be simpler to just have the child components import the hooks as needed?  