### PR TITLE
Add TreeRemoveDialog to handle modal remove flow

### DIFF
--- a/client/src/components/Form/FormRadioGroup.js
+++ b/client/src/components/Form/FormRadioGroup.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {
+  FormControl,
+  FormLabel,
+  RadioGroup,
+} from '@mui/material';
+import { Controller, useFormContext } from 'react-hook-form';
+import FormErrorMessage from './FormErrorMessage';
+
+export default function FormRadioGroup({
+  name, label, options = [], rules, sx, ...restProps
+}) {
+  const { control } = useFormContext();
+
+  // We have to wrap the Controller around the RadioGroup, not the FormControl, since the
+  // RadioGroup is what is updating the actual value.
+  return (
+    <>
+      <FormControl
+        component="fieldset"
+        fullWidth
+      >
+        <FormLabel component="legend">{label}</FormLabel>
+        <Controller
+          name={name}
+          control={control}
+          rules={rules}
+          as={
+            <RadioGroup
+              aria-label={label}
+              sx={sx}
+            >
+              {options}
+            </RadioGroup>
+          }
+          {...restProps}
+        />
+      </FormControl>
+      <FormErrorMessage name={name} label={label} />
+    </>
+  );
+}

--- a/client/src/components/Form/FormScrollableDialog.js
+++ b/client/src/components/Form/FormScrollableDialog.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import ScrollableDialog from '../ScrollableDialog/ScrollableDialog';
+import { Form } from './index';
+import { Button } from '@mui/material';
+
+const isFunction = (value) => typeof value === 'function';
+
+export default function FormScrollableDialog({
+  children, actions, formMethods, onConfirm, onCancel, onError, ...restProps
+}) {
+  const handleSubmit = formMethods.handleSubmit(
+    (data, event) => isFunction(onConfirm) && onConfirm(data, event),
+    (data, event) => isFunction(onError) && onError(data, event)
+  );
+
+  const handleCancel = () => isFunction(onCancel) && onCancel();
+
+  const actionButtons = actions.map((action, i) => {
+    const { confirm, cancel } = action;
+
+    if (confirm) {
+      return (
+        <Button
+          key={i}
+          type="submit"
+          onClick={handleSubmit}
+        >
+          {confirm}
+        </Button>
+      );
+    } else {
+      return (
+        <Button
+          key={i}
+          onClick={handleCancel}
+        >
+          {cancel}
+        </Button>
+      );
+    }
+  });
+
+  return (
+    <ScrollableDialog
+      onClose={handleCancel}
+      actions={actionButtons}
+      {...restProps}
+    >
+      <Form
+        {...formMethods}
+        onSubmit={handleSubmit}
+      >
+        {children}
+      </Form>
+    </ScrollableDialog>
+  );
+}

--- a/client/src/components/Form/FormScrollableDialog.js
+++ b/client/src/components/Form/FormScrollableDialog.js
@@ -3,17 +3,13 @@ import ScrollableDialog from '../ScrollableDialog/ScrollableDialog';
 import { Form } from './index';
 import { Button } from '@mui/material';
 
-const isFunction = (value) => typeof value === 'function';
-
 export default function FormScrollableDialog({
   children, actions, formMethods, onConfirm, onCancel, onError, ...restProps
 }) {
   const handleSubmit = formMethods.handleSubmit(
-    (data, event) => isFunction(onConfirm) && onConfirm(data, event),
-    (data, event) => isFunction(onError) && onError(data, event)
+    (data, event) => onConfirm(data, event),
+    (data, event) => typeof onError === 'function' && onError(data, event)
   );
-
-  const handleCancel = () => isFunction(onCancel) && onCancel();
 
   const actionButtons = actions.map((action, i) => {
     const { confirm, cancel } = action;
@@ -32,7 +28,7 @@ export default function FormScrollableDialog({
       return (
         <Button
           key={i}
-          onClick={handleCancel}
+          onClick={onCancel}
         >
           {cancel}
         </Button>
@@ -42,7 +38,7 @@ export default function FormScrollableDialog({
 
   return (
     <ScrollableDialog
-      onClose={handleCancel}
+      onClose={onCancel}
       actions={actionButtons}
       {...restProps}
     >

--- a/client/src/components/Form/index.js
+++ b/client/src/components/Form/index.js
@@ -3,6 +3,8 @@ export { default as FormAutocomplete } from "./FormAutocomplete";
 export { default as FormCheckbox } from "./FormCheckbox";
 export { default as FormDecimalField } from "./FormDecimalField";
 export { default as FormErrorMessage } from "./FormErrorMessage";
+export { default as FormRadioGroup } from "./FormRadioGroup";
+export { default as FormScrollableDialog } from "./FormScrollableDialog";
 export { default as FormSelect } from "./FormSelect";
 export { default as FormTextField } from "./FormTextField";
 export { default as FormTreeGroup } from "./FormTreeGroup";

--- a/client/src/pages/addtree/AddTreeModal.js
+++ b/client/src/pages/addtree/AddTreeModal.js
@@ -44,7 +44,7 @@ const AddTreeModal = ({
     email: email || '',
     idReference: `WTT${format(new Date(), 'yyyyMMdd')}${randomInteger(1000000, 9999999)}`,
   };
-  // Set mode: all to check for errors when fields change or lose focus.
+  // Set mode to "all" to check for errors when fields change or lose focus.
   const formMethods = useForm({ defaultValues, mode: 'all' });
   const { handleSubmit } = formMethods;
 

--- a/client/src/pages/treedata/TreeData.scss
+++ b/client/src/pages/treedata/TreeData.scss
@@ -13,31 +13,6 @@
   margin: -.2rem -.2rem -1rem auto;
 }
 
-.treeremoval-btn {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-}
-
-.treeremoval__reason{
-  padding: 0 5px;
-  width:100%;
-}
-.treeremoval__reason-btngrp{
-  justify-content: center;
-}
-.treeremoval__reason-btn{
-  padding: 3px;
-}
-.treeremoval__reason-input {
-  border: 1px solid gray;
-  background-color: #f9f6f2;
-  margin: 3px 0;
-  padding: 0.375rem 0.75rem;
-  font-size: 1.2rem;
-  width:100%;
-}
-
 .treedata__edit {
   padding: 5px 0;
 }
@@ -410,10 +385,6 @@ element.style {
   }
 }
 
-.treeremoval {
-  padding: 20px 0;
-}
-
 .addtreepage {
   display: inline-block;
   position: absolute;
@@ -430,15 +401,6 @@ element.style {
   justify-content: flex-start;
 }
 .datatable__row {
-  // display: flex;
-  // flex-direction: row;
-  // justify-content: flex-start;
-  /* flex-basis: 15%; */
-  // flex-grow: 0;
-  // flex-shrink: 0;
-  // flex-basis: 25% 75%;
-  // border-color: #e9ecef;
-  // padding: 0 9px;
   border-color: #e9ecef;
   padding: 0 9px;
 }
@@ -447,7 +409,6 @@ element.style {
 }
 
 .datatable__span-key {
-  // flex-basis: 50%;
   width: 8em;
   display: inline-block;
 }

--- a/client/src/pages/treedata/TreeEditDialog.js
+++ b/client/src/pages/treedata/TreeEditDialog.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { useAuth0 } from '@auth0/auth0-react';
-import { Button } from '@mui/material';
 import format from 'date-fns/format';
 import { useTreeDataMutation, useTreeHistoryMutation } from '../../api/queries';
-import { Form, FormCheckbox } from '../../components/Form';
+import { FormCheckbox, FormScrollableDialog } from '../../components/Form';
 import TreeNameAndSize from '../../components/Tree/TreeNameAndSize';
-import ScrollableDialog from '../../components/ScrollableDialog/ScrollableDialog';
 
 function noNulls(object) {
 	return Object.keys(object).reduce((result, key) => {
@@ -37,9 +35,8 @@ export default function TreeEditDialog({
     newTree: false
   };
   const formMethods = useForm({ defaultValues });
-  const { handleSubmit } = formMethods;
 
-  const onSubmit = async (formData, event) => {
+  const handleConfirm = (formData, event) => {
     // Try to prevent the form submission from reloading the page if there's an error.
     event.preventDefault();
 
@@ -48,8 +45,9 @@ export default function TreeEditDialog({
     // Extract the newTree boolean, since we don't want to send it to the backend.
     const { newTree, ...data } = formData;
 
-    // Only update the backend if the values have actually changed.
-    if (JSON.stringify(data) !== JSON.stringify(initialValues)) {
+    // Only update the backend if the values have actually changed.  If the new tree checkbox is on
+    // and the names haven't changed, that just means tree's been replaced with the same type.
+    if (JSON.stringify(data) !== JSON.stringify(initialValues) || newTree) {
       const sendData = {
         idTree,
         ...data,
@@ -82,46 +80,29 @@ export default function TreeEditDialog({
     setShowEditDialog(false);
   };
 
-  const onError = (errorLog, e) => console.error('errors, e', errorLog, e);
+  const handleCancel = () => setShowEditDialog(false);
 
-  const handleClose = () => setShowEditDialog(false);
-
-  const handleFormSubmit = handleSubmit(onSubmit, onError);
+  const handleError = (errorLog, e) => console.error('errors, e', errorLog, e);
 
   return (
-    <ScrollableDialog
+    <FormScrollableDialog
       title="Edit Tree"
       open={showEditDialog}
-      onClose={handleClose}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+      onError={handleError}
       fullScreen={false}
-      actions={
-        <>
-          <Button
-            onClick={handleClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="submit"
-            onClick={handleFormSubmit}
-          >
-            Save Changes
-          </Button>
-        </>
-      }
+      maxWidth="xs"
+      formMethods={formMethods}
+      actions={[{ cancel: 'Cancel' }, { confirm: 'Save Changes' }]}
     >
-      <Form
-        {...formMethods}
-        onSubmit={handleSubmit(onSubmit, onError)}
-      >
-        <TreeNameAndSize />
+      <TreeNameAndSize />
 
-        <FormCheckbox
-          name="newTree"
-          label="Replace existing tree"
-          sx={{ mt: 2 }}
-        />
-      </Form>
-    </ScrollableDialog>
+      <FormCheckbox
+        name="newTree"
+        label="Replace existing tree"
+        sx={{ mt: 2 }}
+      />
+    </FormScrollableDialog>
   );
 }

--- a/client/src/pages/treedata/TreeHeader.js
+++ b/client/src/pages/treedata/TreeHeader.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { Button } from '@mui/material';
 import format from 'date-fns/format';
-import { env } from '../../util/config';
 
 export default function TreeHeader({
   treeData, edit, vacant,

--- a/client/src/pages/treedata/TreeRemoval.js
+++ b/client/src/pages/treedata/TreeRemoval.js
@@ -7,7 +7,7 @@ import TreeRemoveDialog from './TreeRemoveDialog';
 
 export default function TreeRemoval({ idTree, common, notes }) {
   const { user, isAuthenticated, loginWithRedirect } = useAuth0();
-  const [showDelete, setShowDelete] = useState(true);
+  const [showRemoveButton, setShowRemoveButton] = useState(true);
   const [showRemovalDialog, setShowRemovalDialog] = useState(false);
   const mutateTreeData = useTreeDataMutation();
   const mutateHistory = useTreeHistoryMutation();
@@ -17,16 +17,13 @@ export default function TreeRemoval({ idTree, common, notes }) {
     setShowRemovalDialog(true);
   };
 
-  const handleConfirm = ({ reason, otherReason }) => {
+  const handleConfirm = ({ comment }) => {
     const functionName = 'handleRemoveTree';
 
     try {
       const now = Date.now();
       const today = format(now, 'yyyy-MM-dd');
       const dateVisit = format(now, 'yyyy-MM-dd HH:mm:ss');
-      const comment = reason === 'other'
-        ? otherReason || 'Other'
-        : reason;
       const sendTreeHistory = {
         idTree,
         date_visit: dateVisit,
@@ -42,18 +39,17 @@ export default function TreeRemoval({ idTree, common, notes }) {
         health: 'vacant',
         notes,
         datePlanted: dateVisit,
-        // TODO: SHOULD NOTES OF PREVIOUS TREE BE DELETED or concated
       };
       const newNote = `${common} was removed by ${user.nickname} ${today} - "${comment}"`;
 
       sendTreeData.notes = (notes && notes !== newNote)
-        ? `${newNote}, ${notes}`
+        ? `${notes ? notes + '\n' : ''}${newNote}`
         : newNote;
 
       mutateHistory.mutate(sendTreeHistory);
       mutateTreeData.mutate(sendTreeData);
 
-      setShowDelete(false);
+      setShowRemoveButton(false);
     } catch (err) {
       console.error('CATCH', functionName, 'err', err);
     }
@@ -61,7 +57,7 @@ export default function TreeRemoval({ idTree, common, notes }) {
 
   return (
     <div>
-      {showDelete && (
+      {showRemoveButton && (
         <Button
           variant="contained"
           onClick={handleRemoveClick}

--- a/client/src/pages/treedata/TreeRemoveDialog.js
+++ b/client/src/pages/treedata/TreeRemoveDialog.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import {
+  FormControlLabel,
+  Radio,
+  TextField,
+} from '@mui/material';
+import { FormRadioGroup, FormTextField } from '../../components/Form';
+import FormScrollableDialog from '../../components/Form/FormScrollableDialog';
+
+export default function TreeRemoveDialog({
+  open, setOpen, onConfirm,
+}) {
+  const formMethods = useForm({
+    defaultValues: {
+      reason: 'dead',
+      otherReason: ''
+    }
+  });
+  const { setValue } = formMethods;
+  const options = [
+    {
+      value: 'dead',
+      label: 'Dead'
+    },
+    {
+      value: 'noWater',
+      label: 'No water'
+    },
+    {
+      value: 'insects',
+      label: 'Insects or disease'
+    },
+    {
+      value: 'other',
+      // For this option, use a custom label containing a text field, so the user can specify a
+      // different reason for removing the tree.  We have to manually set the form's current value
+      // to 'other' when the text field is focused so it stays in sync.
+      label: <FormTextField
+        name="otherReason"
+        label="Other reason"
+        sx={{ mt: -1 }}
+        as={<TextField onFocus={() => setValue('reason', 'other')} />}
+      />,
+    },
+  ].map(({ value, label }) => (
+    <FormControlLabel
+      key={value}
+      value={value}
+      control={<Radio />}
+      label={label}
+      // We seem to have to pick out this label class to make each control extend the full width
+      // of the radio group.
+      sx={{
+        '& .MuiFormControlLabel-label': {
+          width: '100%',
+        },
+      }}
+    />
+  ));
+
+  const handleConfirm = (data, event) => {
+    // Try to prevent the form submission from reloading the page if there's an error.
+    event.preventDefault();
+    setOpen(false);
+    onConfirm(data);
+  };
+
+  const handleCancel = () => setOpen(false);
+
+  const handleError = (errorLog, e) => console.error('errors, e', errorLog, e);
+
+  return (
+    <FormScrollableDialog
+      title="Remove Tree"
+      open={open}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+      onError={handleError}
+      fullScreen={false}
+      maxWidth="xs"
+      formMethods={formMethods}
+      actions={[{ cancel: 'Cancel' }, { confirm: 'Remove Tree' }]}
+    >
+      <FormRadioGroup
+        name="reason"
+        label="Reason for removal"
+        options={options}
+      />
+    </FormScrollableDialog>
+  );
+}

--- a/client/src/pages/treedata/TreeRemoveDialog.js
+++ b/client/src/pages/treedata/TreeRemoveDialog.js
@@ -8,29 +8,45 @@ import {
 import { FormRadioGroup, FormTextField } from '../../components/Form';
 import FormScrollableDialog from '../../components/Form/FormScrollableDialog';
 
+const removalReasons = [
+  {
+    value: 'diedFromUnderWatering',
+    label: 'Died from under-watering',
+  },
+  {
+    value: 'diedFromInsects',
+    label: 'Died from insects or disease',
+  },
+  {
+    value: 'diedFromUnknown',
+    label: 'Died from unknown causes',
+  },
+  {
+    value: 'sickOrDamaged',
+    label: 'Sickened or damaged',
+  },
+  {
+    value: 'badSpecies',
+    label: 'Invasive or non-native species',
+  },
+  {
+    value: 'ugly',
+    label: 'Aesthetically unappealing',
+  },
+];
+
 export default function TreeRemoveDialog({
   open, setOpen, onConfirm,
 }) {
   const formMethods = useForm({
     defaultValues: {
-      reason: 'dead',
-      otherReason: ''
-    }
+      reason: removalReasons[0].value,
+      otherReason: '',
+    },
   });
   const { setValue } = formMethods;
-  const options = [
-    {
-      value: 'dead',
-      label: 'Dead'
-    },
-    {
-      value: 'noWater',
-      label: 'No water'
-    },
-    {
-      value: 'insects',
-      label: 'Insects or disease'
-    },
+  const radioButtons = [
+    ...removalReasons,
     {
       value: 'other',
       // For this option, use a custom label containing a text field, so the user can specify a
@@ -59,11 +75,25 @@ export default function TreeRemoveDialog({
     />
   ));
 
-  const handleConfirm = (data, event) => {
+  const handleConfirm = ({ reason, otherReason }, event) => {
     // Try to prevent the form submission from reloading the page if there's an error.
     event.preventDefault();
     setOpen(false);
-    onConfirm(data);
+
+    let comment;
+
+    if (reason === 'other') {
+      comment = otherReason;
+    } else {
+      // Use the label of the selected reason as the comment.
+      const option = removalReasons.find(({ value }) => value === reason);
+
+      comment = option
+        ? option.label
+        : reason;
+    }
+
+    onConfirm({ reason, comment });
   };
 
   const handleCancel = () => setOpen(false);
@@ -85,7 +115,7 @@ export default function TreeRemoveDialog({
       <FormRadioGroup
         name="reason"
         label="Reason for removal"
-        options={options}
+        options={radioButtons}
       />
     </FormScrollableDialog>
   );


### PR DESCRIPTION
- Create FormScrollableDialog.js to simplify dialogs.
- Make Dead the default reason for removal.
- Use FormScrollableDialog in TreeEditDialog.
- In edit dialog, allow names to be unchanged but replace checkbox checked and have the tree updated.
- Add FormScrollableDialog and FormRadioGroup to form/index.js.
- Remove unused CSS.

There's currently not an "are you sure?" confirmation after clicking Remove Tree, but we could add one.

**Desktop remove dialog:**

![image](https://user-images.githubusercontent.com/61631/145925242-c817af32-2158-45a6-8445-3da922d2ac99.png)

**Phone:**

![image](https://user-images.githubusercontent.com/61631/145924689-9ce25075-079e-4fb9-a7a7-997ce41bcc29.png)
