### PR TITLE
Update react-hook-form to 7.22.0

### DIFF
--- a/client/src/components/Form/FormAutocomplete.js
+++ b/client/src/components/Form/FormAutocomplete.js
@@ -4,28 +4,25 @@ import {
   TextField,
   Autocomplete,
 } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import FormErrorMessage from './FormErrorMessage';
 
 export default function FormAutocomplete({
-  name, label, options = [], rules,
+  name, label, options = [], rules, ...restProps
 }) {
-  const { control } = useFormContext();
-
   return (
     <>
       <Controller
         name={name}
-        control={control}
         rules={rules}
-        render={(props) => (
+        render={({ field }) => (
           <Autocomplete
-            {...props}
+            {...field}
             options={options}
             freeSolo
             autoSelect
             handleHomeEndKeys
-            onChange={(_, value) => props.onChange(value)}
+            onChange={(_, value) => field.onChange(value)}
             renderInput={(params) => (
               <TextField
                 {...params}
@@ -33,6 +30,7 @@ export default function FormAutocomplete({
                 variant="standard"
               />
             )}
+            {...restProps}
           />
         )}
       />

--- a/client/src/components/Form/FormCheckbox.js
+++ b/client/src/components/Form/FormCheckbox.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { Checkbox, FormControlLabel } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import FormErrorMessage from './FormErrorMessage';
 
 export default function FormCheckbox({
   name, label, rules, sx, ...restProps
 }) {
-  const { control } = useFormContext();
-
   // We have to wrap the Controller around the Checkbox, not the FormControlLabel, since the
   // Checkbox is what changes the actual value.
   return (
@@ -18,16 +16,14 @@ export default function FormCheckbox({
         control={
           <Controller
             name={name}
-            control={control}
             rules={rules}
-            render={(props) => (
+            render={({ field }) => (
               <Checkbox
-                {...props}
-                checked={props.value}
-                onChange={(e) => props.onChange(e.target.checked)}
+                {...field}
+                checked={field.value}
+                {...restProps}
               />
             )}
-            {...restProps}
           />
         }
       />

--- a/client/src/components/Form/FormErrorMessage.js
+++ b/client/src/components/Form/FormErrorMessage.js
@@ -24,7 +24,7 @@ const messagesByType = {
 };
 
 export default function FormErrorMessage({ name, label = name }) {
-  const { errors } = useFormContext();
+  const { formState: { errors } } = useFormContext();
   const error = errors[name];
 
   if (error) {

--- a/client/src/components/Form/FormRadio.js
+++ b/client/src/components/Form/FormRadio.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { FormControlLabel, Radio } from '@mui/material';
+
+export default function FormRadio({
+  value, label, ...restProps
+}) {
+  // We have to wrap the Controller around the RadioGroup, not the FormControl, since the
+  // RadioGroup is what is updating the actual value.
+  return (
+    <FormControlLabel
+      value={value}
+      label={label}
+      control={<Radio />}
+      {...restProps}
+    />
+  );
+}

--- a/client/src/components/Form/FormRadioGroup.js
+++ b/client/src/components/Form/FormRadioGroup.js
@@ -4,14 +4,12 @@ import {
   FormLabel,
   RadioGroup,
 } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import FormErrorMessage from './FormErrorMessage';
 
 export default function FormRadioGroup({
-  name, label, options = [], rules, sx, ...restProps
+  children, name, label, rules, ...restProps
 }) {
-  const { control } = useFormContext();
-
   // We have to wrap the Controller around the RadioGroup, not the FormControl, since the
   // RadioGroup is what is updating the actual value.
   return (
@@ -23,17 +21,16 @@ export default function FormRadioGroup({
         <FormLabel component="legend">{label}</FormLabel>
         <Controller
           name={name}
-          control={control}
           rules={rules}
-          as={
+          render={({ field }) => (
             <RadioGroup
+              {...field}
               aria-label={label}
-              sx={sx}
+              {...restProps}
             >
-              {options}
+              {children}
             </RadioGroup>
-          }
-          {...restProps}
+          )}
         />
       </FormControl>
       <FormErrorMessage name={name} label={label} />

--- a/client/src/components/Form/FormSelect.js
+++ b/client/src/components/Form/FormSelect.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { FormControl, InputLabel, Select } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import FormErrorMessage from './FormErrorMessage';
 
 export default function FormSelect({
-  name, label, options = [], rules, ...restProps
+  children, name, label, rules, ...restProps
 }) {
-  const { control } = useFormContext();
-
   return (
     <>
       <FormControl
@@ -18,10 +16,15 @@ export default function FormSelect({
         <Controller
           name={name}
           rules={rules}
-          variant="standard"
-          control={control}
-          as={<Select>{options}</Select>}
-          {...restProps}
+          render={({ field }) => (
+            <Select
+              {...field}
+              variant="standard"
+              {...restProps}
+            >
+              {children}
+            </Select>
+          )}
         />
       </FormControl>
       <FormErrorMessage name={name} label={label} />

--- a/client/src/components/Form/FormTextField.js
+++ b/client/src/components/Form/FormTextField.js
@@ -1,24 +1,25 @@
 import React from 'react';
 import { TextField } from '@mui/material';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller } from 'react-hook-form';
 import FormErrorMessage from './FormErrorMessage';
 
 export default function FormTextField({
   name, label, rules, ...restProps
 }) {
-  const { control } = useFormContext();
-
   return (
     <>
       <Controller
         name={name}
-        label={label}
         rules={rules}
-        variant="standard"
-        fullWidth
-        control={control}
-        as={TextField}
-        {...restProps}
+        render={({ field }) => (
+          <TextField
+            {...field}
+            label={label}
+            variant="standard"
+            fullWidth
+            {...restProps}
+          />
+        )}
       />
       <FormErrorMessage name={name} label={label} />
     </>

--- a/client/src/components/Form/FormTreeGroup.js
+++ b/client/src/components/Form/FormTreeGroup.js
@@ -3,7 +3,7 @@ import { styled } from '@mui/material';
 
 const Group = styled('div')`
   margin-bottom: 15px;
-  border-radius: 0 0 25px 25px;
+  border-radius: 0 0 20px 25px;
   background-color: #658e52;
   background-image: url(../../assets/images/addtree/all_leaf.svg);
   background-repeat: no-repeat;
@@ -11,6 +11,10 @@ const Group = styled('div')`
   background-size: cover;
   display: flex;
   flex-direction: column;
+
+  &:last-of-type {
+    margin-bottom: 0;
+  }
 `;
 
 const Header = styled('div')`

--- a/client/src/components/Form/index.js
+++ b/client/src/components/Form/index.js
@@ -3,6 +3,7 @@ export { default as FormAutocomplete } from "./FormAutocomplete";
 export { default as FormCheckbox } from "./FormCheckbox";
 export { default as FormDecimalField } from "./FormDecimalField";
 export { default as FormErrorMessage } from "./FormErrorMessage";
+export { default as FormRadio } from "./FormRadio";
 export { default as FormRadioGroup } from "./FormRadioGroup";
 export { default as FormScrollableDialog } from "./FormScrollableDialog";
 export { default as FormSelect } from "./FormSelect";

--- a/client/src/components/Tree/TreeNameAndSize.js
+++ b/client/src/components/Tree/TreeNameAndSize.js
@@ -24,7 +24,7 @@ export default function TreeNameAndSize() {
   const { watch, setValue } = useFormContext();
   // Get the value of common that was specified by our parent's defaultValues, so that we can
   // default the lastCommon state to it.
-  let { common, scientific, genus } = watch(['common', 'scientific', 'genus']);
+  let [common, scientific, genus] = watch(['common', 'scientific', 'genus']);
   const [lastCommon, setLastCommon] = useState(common);
 
   useEffect(() => {

--- a/client/src/pages/addtree/TreeAddress.js
+++ b/client/src/pages/addtree/TreeAddress.js
@@ -5,6 +5,8 @@ import {
   FormTextField,
   FormSelect,
   FormTreeGroup,
+  FormRadio,
+  FormRadioGroup,
 } from '../../components/Form';
 
 // Add keys to each item in the map() call below.
@@ -84,8 +86,9 @@ export default function TreeAddress() {
       <FormSelect
         name="state"
         label="State"
-        options={stateMenuItems}
-      />
+      >
+        {stateMenuItems}
+      </FormSelect>
 
       <FormDecimalField
         name="zip"
@@ -104,6 +107,22 @@ export default function TreeAddress() {
         label="Longitude"
         disabled
       />
+
+      <FormRadioGroup
+        name="owner"
+        label="Type of land"
+        aria-label="owner"
+        row
+      >
+        <FormRadio
+          value="public"
+          label="Public"
+        />
+        <FormRadio
+          value="private"
+          label="Private"
+        />
+      </FormRadioGroup>
     </FormTreeGroup>
   );
 }

--- a/client/src/pages/addtree/TreeInfo.js
+++ b/client/src/pages/addtree/TreeInfo.js
@@ -9,7 +9,7 @@ import {
 import TreeNameAndSize from '../../components/Tree/TreeNameAndSize';
 
 // Create an array of tree health items, reversed so that "good" comes first.
-const healthOptions = treeHealth.getNameValuePairs().reverse()
+const healthMenuItems = treeHealth.getNameValuePairs().reverse()
   .map(([name]) => <MenuItem key={name} value={name}>{name}</MenuItem>);
 
 export default function TreeInfo() {
@@ -21,14 +21,15 @@ export default function TreeInfo() {
         type="date"
         name="datePlanted"
         label="Date Planted"
-        rules={{ required: true, minLength: 1, maxLength: 100 }}
+        rules={{ required: true, minLength: 1, maxLength: 10 }}
       />
 
       <FormSelect
         name="health"
         label="Health"
-        options={healthOptions}
-      />
+      >
+        {healthMenuItems}
+      </FormSelect>
 
       <FormTextField
         name="notes"

--- a/client/src/pages/addtree/TreePlanter.js
+++ b/client/src/pages/addtree/TreePlanter.js
@@ -1,40 +1,12 @@
 import React from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
-import {
-  Radio,
-  RadioGroup,
-  FormControlLabel,
-} from '@mui/material';
 import {
   FormTextField,
   FormTreeGroup,
 } from '../../components/Form';
 
 export default function TreePlanter() {
-  const { control } = useFormContext();
-
   return (
     <FormTreeGroup title="Planter">
-      <Controller
-        as={(
-          <RadioGroup aria-label="owner" name="position" row>
-            <FormControlLabel
-              value="public"
-              control={<Radio color="primary" value="public" />}
-              label="Public Land"
-            />
-            <FormControlLabel
-              value="private"
-              control={<Radio color="secondary" value="private" />}
-              label="Private Land"
-            />
-          </RadioGroup>
-        )}
-        name="owner"
-        control={control}
-        size="medium"
-      />
-
       <FormTextField
         name="who"
         label="Organization"

--- a/client/src/pages/treedata/TreeEditDialog.js
+++ b/client/src/pages/treedata/TreeEditDialog.js
@@ -34,7 +34,8 @@ export default function TreeEditDialog({
     ...initialValues,
     newTree: false
   };
-  const formMethods = useForm({ defaultValues });
+  // Set mode to "all" to check for errors when fields change or lose focus.
+  const formMethods = useForm({ defaultValues, mode: 'all' });
 
   const handleConfirm = (formData, event) => {
     // Try to prevent the form submission from reloading the page if there's an error.
@@ -94,7 +95,10 @@ export default function TreeEditDialog({
       fullScreen={false}
       maxWidth="xs"
       formMethods={formMethods}
-      actions={[{ cancel: 'Cancel' }, { confirm: 'Save Changes' }]}
+      actions={[
+        { cancel: 'Cancel' },
+        { confirm: 'Save Changes' }
+      ]}
     >
       <TreeNameAndSize />
 

--- a/client/src/pages/treedata/TreeRemoval.js
+++ b/client/src/pages/treedata/TreeRemoval.js
@@ -3,7 +3,7 @@ import { Button } from '@mui/material';
 import format from 'date-fns/format';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useTreeDataMutation, useTreeHistoryMutation } from '../../api/queries';
-import TreeRemoveDialog from './TreeRemoveDialog';
+import TreeRemovalDialog from './TreeRemovalDialog';
 
 export default function TreeRemoval({ idTree, common, notes }) {
   const { user, isAuthenticated, loginWithRedirect } = useAuth0();
@@ -74,7 +74,7 @@ export default function TreeRemoval({ idTree, common, notes }) {
         </Button>
       )}
       {showRemovalDialog && (
-        <TreeRemoveDialog
+        <TreeRemovalDialog
           open={showRemovalDialog}
           setOpen={setShowRemovalDialog}
           onConfirm={handleConfirm}

--- a/client/src/pages/treedata/TreeRemovalDialog.js
+++ b/client/src/pages/treedata/TreeRemovalDialog.js
@@ -3,7 +3,6 @@ import { useForm } from 'react-hook-form';
 import {
   FormControlLabel,
   Radio,
-  TextField,
 } from '@mui/material';
 import { FormRadioGroup, FormTextField } from '../../components/Form';
 import FormScrollableDialog from '../../components/Form/FormScrollableDialog';
@@ -38,14 +37,16 @@ const removalReasons = [
 export default function TreeRemoveDialog({
   open, setOpen, onConfirm,
 }) {
+  // Set mode to "all" to check for errors when fields change or lose focus.
   const formMethods = useForm({
     defaultValues: {
       reason: removalReasons[0].value,
       otherReason: '',
     },
+    mode: 'all'
   });
   const { setValue } = formMethods;
-  const radioButtons = [
+  const reasonRadioButtons = [
     ...removalReasons,
     {
       value: 'other',
@@ -56,7 +57,7 @@ export default function TreeRemoveDialog({
         name="otherReason"
         label="Other reason"
         sx={{ mt: -1 }}
-        as={<TextField onFocus={() => setValue('reason', 'other')} />}
+        onFocus={() => setValue('reason', 'other')}
       />,
     },
   ].map(({ value, label }) => (
@@ -110,13 +111,17 @@ export default function TreeRemoveDialog({
       fullScreen={false}
       maxWidth="xs"
       formMethods={formMethods}
-      actions={[{ cancel: 'Cancel' }, { confirm: 'Remove Tree' }]}
+      actions={[
+        { cancel: 'Cancel' },
+        { confirm: 'Remove Tree' }
+      ]}
     >
       <FormRadioGroup
         name="reason"
         label="Reason for removal"
-        options={radioButtons}
-      />
+      >
+        {reasonRadioButtons}
+      </FormRadioGroup>
     </FormScrollableDialog>
   );
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^17.0.2",
     "react-csv": "^2.0.3",
     "react-dom": "^17.0.2",
-    "react-hook-form": "^6.15.8",
+    "react-hook-form": "^7.22.0",
     "react-query": "^3.33.2",
     "react-router": "^5.2.1",
     "react-router-dom": "^5.3.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,8 @@ module.exports = (env) => {
         },
         ifNotProduction({
           test: /\.js$/,
-          exclude: /mapbox-gl-legend/,
+          // These modules seem to cause errors with this loader.
+          exclude: /mapbox-gl-legend|react-hook-form/,
           enforce: 'pre',
           use: ['source-map-loader'],
         }),


### PR DESCRIPTION
- Move owner radio buttons to TreeAddress, since it's more related to the location than the planter.
- Rename TreeRemoveDialog to TreeRemovalDialog.
- Change `as` props to `render` props.
- Remove control props, as they're unnecessary when the Controller is in a FormContextProvider.
- Move restProps to the rendered element, as the Controller no longer forwards the extra props.
- Update watch() calls.
- Extract errors from formState, since it's moved.
- Pass menu items and radio buttons as children of Select and FormRadioGroup, instead of an options prop.
- Report errors immediately in TreeEditDialog and TreeRemovalDialog.
- Add FormRadio component for FormRadioGroup children.
- No margin on the last FormTreeGroup.
- Ignore react-hook-form in the source-map-loader, since it throws errors.

PR #147 should be merged first. 

![image](https://user-images.githubusercontent.com/61631/146096174-371a9d42-5608-47a9-b266-dbbf65bdcd77.png)
