### PR TITLE
Always logout to the origin

### DIFF
--- a/client/src/components/Auth/AuthButton.js
+++ b/client/src/components/Auth/AuthButton.js
@@ -2,21 +2,15 @@ import React from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import useAuthUtils from '../../components/Auth/useAuthUtils';
 
-const protectedRoutes = /userprofile/i;
-
 const AuthButton = () => {
   const { isAuthenticated, logout } = useAuth0();
   const { loginToCurrentPage } = useAuthUtils();
 
   const handleClick = () => {
     if (isAuthenticated) {
-      // If the user is currently on a protected route, send them back to the root page, since they
-      // won't be able to view the current page.  Otherwise, keep them on the same page.
-      const destination = protectedRoutes.test(location.pathname)
-        ? location.origin
-        : location.href;
-
-      logout({ returnTo: destination });
+      // Only logging out to the root seems to be allowed, so if the user is on a subpage like
+      // /contact, they'll be sent back to /.
+      logout({ returnTo: location.origin });
     } else {
       loginToCurrentPage();
     }


### PR DESCRIPTION
Don't try to return the user to the page they were on when logging out, as the Auth0 redirect throws an error.  Instead, always return them to `/`, which is how it currently works in product.

@zoobot this fixes the logout error on dev.