### PR TITLE
Split the code into chunks

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
@@ -10,15 +10,19 @@ import Privacy from '../../pages/privacy/Privacy';
 import License from '../../pages/license/License';
 import UserProfile from '../../pages/userprofile/UserProfile';
 import Contact from '../../pages/contact/Contact';
-import Data from '../../pages/data/Data';
 import NotFound from '../../pages/notFound/NotFound';
 import RequireAuth from '../Auth/RequireAuth';
 import RedirectWithHash from '../Auth/RedirectWithHash';
+import Loading from '../Auth/Loading';
+import "../../styles/app.scss";
+
+// Lazy-load the data page, so that we only load the large JSON files it uses if needed.
+const Data = React.lazy(() => import(/* webpackChunkName: "Data" */ '../../pages/data/Data'));
 
 // Create a client for react-query calls.
 const queryClient = new QueryClient();
 
-// Create a default MUI theme.
+// Create a default MUI theme so that any child can access it for styling.
 const theme = createTheme();
 
 function App() {
@@ -28,18 +32,20 @@ function App() {
         <BrowserRouter basename="/">
           <Auth0ProviderWithRedirect>
             <Header />
-            <Routes>
-              <Route path="/" element={<Mapper />} />
-              <Route path="/treemap" element={<Mapper />} />
-              <Route path="/userprofile" element={<RequireAuth component={UserProfile} />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/privacy" element={<Privacy />} />
-              <Route path="/license" element={<License />} />
-              <Route path="/contact" element={<Contact />} />
-              <Route path="/data" element={<Data />} />
-              <Route path="/go" element={<RedirectWithHash param="to" />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <Suspense fallback={<Loading />}>
+              <Routes>
+                <Route path="/" element={<Mapper />} />
+                <Route path="/treemap" element={<Mapper />} />
+                <Route path="/userprofile" element={<RequireAuth component={UserProfile} />} />
+                <Route path="/about" element={<About />} />
+                <Route path="/privacy" element={<Privacy />} />
+                <Route path="/license" element={<License />} />
+                <Route path="/contact" element={<Contact />} />
+                <Route path="/data" element={<Data />} />
+                <Route path="/go" element={<RedirectWithHash param="to" />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </Suspense>
           </Auth0ProviderWithRedirect>
         </BrowserRouter>
       </QueryClientProvider>

--- a/client/src/components/Auth/Loading.js
+++ b/client/src/components/Auth/Loading.js
@@ -1,12 +1,27 @@
 import React from 'react';
-
-const loadingImg = 'assets/images/logos/waterthetrees-fatgraff.svg';
+import { Grid, Typography } from '@mui/material';
+import Footer from '../Footer';
 
 const Loading = () => (
-  <div className="spinner">
-    <img src={loadingImg} alt="Loading..." />
-    <h1>Loading...</h1>
-  </div>
+  <Grid container
+    justifyContent="center"
+    alignItems="center"
+    direction="column"
+    sx={{ height: '100vh' }}
+  >
+    <Grid item>
+      <img src='assets/images/addtree/tree16.svg'
+        alt="Loading..."
+        style={{ width: '100px' }}
+      />
+    </Grid>
+    <Grid item>
+      <Typography variant="h3" sx={{ mt: 2 }}>
+        Loading...
+      </Typography>
+    </Grid>
+    <Footer />
+  </Grid>
 );
 
 export default Loading;

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -1,5 +1,3 @@
-@import '../../styles/app';
-
 .sidebar {
  background-color: transparent;
  position: fixed;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,11 @@ module.exports = (env) => {
       publicPath: '/',
       clean: true,
     },
+    optimization: {
+      splitChunks: {
+        chunks: 'all',
+      },
+    },
     devServer: {
       // Port 3000 is baked into the configuration for the mapbox API, so the
       // dev-server needs to use it so that we can hit the API
@@ -39,14 +44,13 @@ module.exports = (env) => {
           include: path.resolve(__dirname, 'client/src'),
           use: ['babel-loader'],
         },
-// TODO: for now, comment out source-map-loader, which is complaining about more modules.
-//        ifNotProduction({
-//          test: /\.js$/,
-//          // These modules seem to cause errors with this loader.
-//          exclude: /mapbox-gl-legend|react-hook-form/,
-//          enforce: 'pre',
-//          use: ['source-map-loader'],
-//        }),
+        ifNotProduction({
+          test: /\.js$/,
+          // These modules seem to cause errors with this loader.
+          exclude: /mapbox-gl-legend|react-hook-form|react-router/,
+          enforce: 'pre',
+          use: ['source-map-loader'],
+        }),
         {
           test: /\.(jpe?g|png|gif|woff|woff2|eot|ttf|svg|md)(\?[a-z0-9=.]+)?$/,
           type: 'asset/resource',


### PR DESCRIPTION
- Load the /data page's code on demand, so that the user doesn't incur the cost of the full tree data when they're just viewing the map.
- Re-enable source-map-loader, while ignoring react-router.
- Clean up the Loading element and add a visible icon.
- Don't load app.scss in Sidebar.scss, and let the App component include it.

This increases the usage ratio of the JS loaded on the main page from 53% to 91%.