### PR TITLE
Create custom TreeLayerLegend to control the layers

### DIFF
--- a/client/src/pages/mapper/MapboxLegend.js
+++ b/client/src/pages/mapper/MapboxLegend.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export class MapboxLegend {
+  container = null;
+  map = null;
+  type = null;
+  props = null;
+
+  constructor({ type, props = {} }) {
+    this.type = type;
+    this.props = props;
+  }
+
+  onAdd(map) {
+    this.map = map;
+    this.container = document.createElement('div');
+    this.container.className = 'mapboxgl-ctrl mapboxgl-ctrl-group';
+
+    ReactDOM.render(React.createElement(this.type, { ...this.props, map }), this.container);
+
+    return this.container
+  }
+
+  onRemove() {
+    if (this.container) {
+      // Force the React components to do any unmounting that's needed.
+      ReactDOM.render(null, this.container);
+      this.container.parentNode.removeChild(this.container);
+      this.container = null;
+      this.map = null;
+    }
+  }
+}

--- a/client/src/pages/mapper/TreeLayerLegend.js
+++ b/client/src/pages/mapper/TreeLayerLegend.js
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  FormGroup,
+  FormLabel, IconButton,
+  styled,
+} from '@mui/material';
+import { Close, FormatListBulleted } from '@mui/icons-material';
+
+const CloseButton = (props) => (
+  <IconButton
+    size="small"
+    title="Close map legend"
+    sx={{
+      margin: '-.35em -.5em 0 0',
+      // We have to override the `mapboxgl-ctrl-group button` style that would otherwise
+      // apply to this button.
+      display: 'inline-block !important',
+    }}
+    {...props}
+  >
+    <Close />
+  </IconButton>
+);
+
+const Dot = styled('div')(({ color, filled }) => `
+  width: 1em;
+  height: 1em;
+  margin-right: .25em;
+  background-color: ${filled ? color : 'transparent'};
+  border: solid 2px ${color};
+  border-radius: 50%;
+  display: inline-block;
+`);
+
+const DotCheckbox = ({ name, color, checked, onChange }) => (
+  <Checkbox
+    name={name}
+    checked={checked}
+    icon={<Dot color={color} />}
+    // We pass a 1 or 0 for filled instead of a boolean, as React will complain otherwise.  This
+    // does cause a filled="1" attribute to be applied to the div, but it's the simplest solution.
+    // https://github.com/emotion-js/emotion/issues/2193
+    checkedIcon={<Dot color={color} filled={1} />}
+    onChange={onChange}
+    sx={{ py: .5, pr: .5 }}
+  />
+);
+
+const LayerControl = ({ layer, label, color, checked, onChange }) => (
+  <FormControlLabel
+    control={
+      <DotCheckbox
+        name={layer}
+        checked={checked}
+        color={color}
+        onChange={onChange}
+      />
+    }
+    label={label}
+    sx={{
+      mx: 0,
+      pl: 0,
+      pr: 1,
+      userSelect: 'none',
+      '&:hover': {
+        backgroundColor: '#eee'
+      }
+    }}
+  />
+);
+
+export default function TreeLayerLegend({
+  map, title, targets, expanded = false
+}) {
+  const defaultVisibility = targets.reduce((result, target) => ({ ...result, [target.layer]: true }), {});
+  const [layerVisibility, setLayerVisibility] = useState(defaultVisibility);
+  const [isMapLoaded, setIsMapLoaded] = useState(map.loaded());
+  const [isExpanded, setIsExpanded] = useState(expanded);
+
+  useEffect(() => {
+    if (!isMapLoaded) {
+      const handleMapLoaded = () => {
+        setIsMapLoaded(true);
+        map.off('load', handleMapLoaded);
+
+        // Annoyingly, the visibility property defaults to undefined if it's not set when the layer
+        // is added, even though the layer is visible by default.  So once the map is loaded, go
+        // through all the layers and change undefined to visible.
+        // https://github.com/mapbox/mapbox-gl-js/issues/8733
+        for (let { layer } of targets) {
+          if (map.getLayoutProperty(layer, 'visibility') === undefined) {
+            map.setLayoutProperty(layer, 'visibility', 'visible');
+          }
+        }
+      };
+
+      map.on('load', handleMapLoaded);
+    }
+  }, [map, isMapLoaded]);
+
+  useEffect(() => {
+    for (let { layer } of targets) {
+      if (map.getLayer(layer)) {
+        const currentVisible = map.getLayoutProperty(layer, 'visibility') === 'visible';
+        const nextVisible = layerVisibility[layer];
+
+        if (currentVisible !== nextVisible) {
+          map.setLayoutProperty(layer, 'visibility', nextVisible ? 'visible' : 'none');
+        }
+      }
+    }
+  }, [layerVisibility]);
+
+  const handleChange = (event) => {
+    const { name } = event.target;
+    const nextVisible = !layerVisibility[name];
+
+    setLayerVisibility({ ...layerVisibility, [name]: nextVisible });
+  };
+
+  const handleExpandClick = () => setIsExpanded(!isExpanded);
+
+  return (
+    isExpanded
+      ? (
+        <Box sx={{ p: 1 }}>
+          <FormControl
+            component="fieldset"
+            variant="standard"
+          >
+            <FormLabel
+              component="legend"
+              sx={{ mb: .25 }}
+            >
+              {title}
+              <CloseButton onClick={handleExpandClick} />
+            </FormLabel>
+            <FormGroup>
+              {targets.map(({ layer, label, color }) => (
+                <LayerControl
+                  key={layer}
+                  layer={layer}
+                  label={label}
+                  color={color}
+                  checked={layerVisibility[layer]}
+                  onChange={handleChange}
+                />))}
+            </FormGroup>
+          </FormControl>
+        </Box>
+      ) : (
+        <button
+          title="Show map legend"
+          onClick={handleExpandClick}
+        >
+          <FormatListBulleted />
+        </button>
+      )
+  )
+}

--- a/client/src/util/treeHealth.js
+++ b/client/src/util/treeHealth.js
@@ -35,7 +35,7 @@ export const treeHealth = {
     return healthInfo.map(([name], value) => [name, value]);
   },
   getColorByName(name, colorType) {
-    return healthByName[name][colorType];
+    return (healthByName[name] || healthByName.default)[colorType];
   },
   getPaintColors(colorType) {
     const colors = healthInfo.reduce((result, [name]) =>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@emotion/styled": "^11.6.0",
     "@mui/icons-material": "^5.1.1",
     "@mui/material": "^5.1.1",
-    "@watergis/mapbox-gl-legend": "^1.2.1",
     "clsx": "^1.1.1",
     "compression": "^1.7.4",
     "date-fns": "2.25.0",


### PR DESCRIPTION
- Create MapboxLegend class to handle adding a React component as a map control.
- Remove mapbox-gl-legend library, saving ~450K from the bundle.
- Support collapsing and expanding the legend.
- Collapse the legend by default.
- Show hover state on each control.
- Fix default layer visibility being undefined when the map first loads.
- Add colored circular checkboxes for each layer.

The `mapbox-gl-legend` library was including the `legend-symbol` library, which was huge.  So writing our own React version saves a lot of code.  The colored dots don't scale as the map zooms, and now serve as the checkboxes for the legend.  

The legend is shown at the bottom-right, and collapses to a small button:

![image](https://user-images.githubusercontent.com/61631/147716137-e49f01c5-edef-4c78-823b-027af9ad92e7.png) ![image](https://user-images.githubusercontent.com/61631/147716152-a266058e-190c-4d8e-8fe3-d6efd00bb298.png)

PR #167 should be merged first.