### PR TITLE
Update `mapbox-gl` to 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "compression": "^1.7.4",
     "date-fns": "2.25.0",
     "express": "^4.17.1",
-    "mapbox-gl": "^1.13.2",
+    "mapbox-gl": "^2.7.0",
     "morgan": "^1.10.0",
     "react": "^17.0.2",
     "react-csv": "^2.0.3",


### PR DESCRIPTION
Didn't really see much change in loading speed for the map, but no bugs, either.  And this new version of Mapbox adds some useful features, like being able to have a single event handler listen to multiple layers at once.