### PR TITLE
Use `setQueryData()` to cache the data from the old vector tiles upon tree selection

### DIFF
--- a/client/src/pages/map/Map/Map.js
+++ b/client/src/pages/map/Map/Map.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import mapboxgl from 'mapbox-gl';
 import { Alert, Box, Typography } from '@mui/material';
+import { useQueryClient } from 'react-query';
 import { mapboxAccessToken } from '@/util/config';
 import { tilesServerEndpoints } from '@/api/apiEndpoints';
 import { treeHealth } from '@/util/treeHealth';
@@ -70,6 +71,7 @@ export default function Map({
 }) {
   const [map, setMap] = useState(null);
   const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const queryClient = useQueryClient();
   const selectionEnabledRef = useRef(selectionEnabled);
   const currentFeature = useRef(null);
 
@@ -130,13 +132,23 @@ export default function Map({
           }
 
           const [feature] = mapboxMap.queryRenderedFeatures([x, y], { layers: layerIDs });
-// TODO: set the tree data directly from properties here?  doesn't seem to contain healthnum
 
           if (feature) {
-            const { id } = feature.properties;
+            const { properties, properties: { id } } = feature;
+            const queryKeys = ['trees', { id }];
 
-            mapboxMap.getCanvas().style.cursor = 'pointer';
+            // Cache the properties from the vector tile as the data for the /trees query that will
+            // be triggered by the setCurrentTreeId() call below.  The TreeDetailsPanel will first
+            // get this cached data and then update it when the server response comes back.  But
+            // only do this if there's no cached data already.  If there is, that data is presumably
+            // the latest response from the server, so we don't want to override it with older data
+            // from the vector tile.
+            if (!queryClient.getQueryState(queryKeys)) {
+              queryClient.setQueryData(queryKeys, properties);
+            }
+
             setCurrentTreeId(id);
+            mapboxMap.getCanvas().style.cursor = 'pointer';
           } else {
             setCurrentTreeId(null);
           }

--- a/client/src/pages/map/NewTree/useNewTree.js
+++ b/client/src/pages/map/NewTree/useNewTree.js
@@ -3,6 +3,7 @@ import React, { useReducer, useMemo, useContext, createContext } from 'react';
 const newTreeInitialState = {
   coords: null,
   result: null,
+  isPlanting: false,
   isPanelOpen: false,
   isDragging: false,
 };
@@ -12,7 +13,13 @@ const newTreeReducer = (state, { type, payload }) => {
     case 'setCoords':
       return { ...state, coords: payload };
 
-    case 'startDrag':
+    case 'beginPlanting':
+      return { ...state, isPlanting: true };
+
+    case 'endPlanting':
+      return { ...newTreeInitialState };
+
+    case 'beginDrag':
       return { ...state, isDragging: true };
 
     case 'endDrag':
@@ -26,9 +33,6 @@ const newTreeReducer = (state, { type, payload }) => {
 
     case 'cancel':
       return { ...state, isPanelOpen: false, result: null };
-
-    case 'reset':
-      return { ...newTreeInitialState };
 
     default:
       throw new Error(`newTreeReducer: unrecognized type: ${type}`);
@@ -44,8 +48,14 @@ const NewTreeProvider = (props) => {
     setCoords(coords) {
       dispatch({ type: 'setCoords', payload: coords });
     },
-    startDrag() {
-      dispatch({ type: 'startDrag' });
+    beginPlanting() {
+      dispatch({ type: 'beginPlanting' });
+    },
+    endPlanting() {
+      dispatch({ type: 'endPlanting' });
+    },
+    beginDrag() {
+      dispatch({ type: 'beginDrag' });
     },
     endDrag() {
       dispatch({ type: 'endDrag' });
@@ -58,9 +68,6 @@ const NewTreeProvider = (props) => {
     },
     cancel() {
       dispatch({ type: 'cancel' });
-    },
-    reset() {
-      dispatch({ type: 'reset' });
     },
   }), [newTreeState, dispatch]);
 

--- a/client/src/pages/map/TreeDetails/CoreData.js
+++ b/client/src/pages/map/TreeDetails/CoreData.js
@@ -10,7 +10,9 @@ export default function CoreData({
     common, scientific, genus, datePlanted, dbh, height,
   } = treeData;
   const wikipediaLink = `https://en.wikipedia.org/wiki/${scientific}`;
-  const planted = format(new Date(datePlanted), 'MMMM d, yyyy');
+  // format() will throw an exception if datePlanted is undefined, so check it first.
+  const planted = datePlanted && format(new Date(datePlanted), 'MMMM d, yyyy');
+
   return (
     <div className="text-left">
       <h1>

--- a/client/src/pages/map/TreeDetails/Info.js
+++ b/client/src/pages/map/TreeDetails/Info.js
@@ -31,7 +31,11 @@ export default function Info({ currentTreeData }) {
     return result;
   }, []);
 
-  return labelValues.length && (
+  if (!labelValues.length) {
+    return null;
+  }
+
+  return (
     <Section
       title="Info"
     >

--- a/client/src/util/treeHealth.js
+++ b/client/src/util/treeHealth.js
@@ -25,11 +25,20 @@ healthByName.default = healthByName.good;
 
 export const treeHealth = {
   getNameByValue(value) {
+    const index = this.getNormalizedValue(value);
+
+    return healthInfo[index][0];
+  },
+  getNormalizedValue(value) {
     const index = parseInt(value, 10);
 
+    // If value is out of bounds for health, return the default value.
     return (index >= 0 && index <= maxValue)
-      ? healthInfo[index][0]
-      : 'good';
+      ? index
+      : healthByName.default.value;
+  },
+  getValueByName(name) {
+    return (healthByName[name] || healthByName.default).value;
   },
   getNameValuePairs() {
     return healthInfo.map(([name], value) => [name, value]);


### PR DESCRIPTION
- When the TreeDetailsPanel does a `/trees?id=` query through react-query, it will get this cached data immediately, and then will update when the server response comes back.
- In CoreData, check that `datePlanted` exists before trying to format it, since `date-fns` will throw an exception otherwise.
- Clean up `Health` to better handle invalid `healthNum` data and to keep the slider and health string display in sync.
- Return null in `Info` if there is no info to display to avoid rendering a 0 when there isn't.
- Add `getNormalizedValue()` and `getValueByName()` to `treeHealth.js`.
- Move planting state out of `NewTree` and into `newTreeState.isPlanting`, so calling `endPlanting()` will automatically cancel the `NewTreePanel`.
- Change `startDrag()` to `beginDrag()`, to be parallel with `beginPlanting()`.