### PR TITLE
Ensure popup closes when mouse leaves a tree circle

### DIFF
--- a/client/src/pages/map/Map/MapboxMarkerPortal.js
+++ b/client/src/pages/map/Map/MapboxMarkerPortal.js
@@ -9,18 +9,22 @@ const events = [
 ];
 
 export class MapboxMarkerPortal extends PureComponent {
-  container = null;
   marker = null;
   addedToMap = false;
+  state = {
+    container: null
+  };
 
   constructor(props) {
     super(props);
   }
 
   componentDidMount() {
-    this.container = document.createElement('div');
+    const container = document.createElement('div');
+
+    this.setState({ container });
     this.marker = new mapboxgl.Marker({
-      element: this.container,
+      element: container,
       ...this.props.options
     });
 
@@ -41,7 +45,7 @@ export class MapboxMarkerPortal extends PureComponent {
     if (map && this.marker) {
       this.marker.remove();
       this.marker = null;
-      this.container = null;
+      this.setState({ container: null });
     }
   }
 
@@ -77,10 +81,13 @@ export class MapboxMarkerPortal extends PureComponent {
   }
 
   render() {
-    return this.container && this.props.visible
+    const { container } = this.state;
+    const { visible, children } = this.props;
+
+    return container && visible
       ? ReactDOM.createPortal(
-        this.props.children,
-        this.container
+        children,
+        container
       )
       : null;
   }

--- a/client/src/pages/map/Map/TreeLayerLegend.js
+++ b/client/src/pages/map/Map/TreeLayerLegend.js
@@ -89,7 +89,6 @@ export default function TreeLayerLegend({
     if (!isMapLoaded) {
       const handleMapLoaded = () => {
         setIsMapLoaded(true);
-        map.off('load', handleMapLoaded);
 
         // Annoyingly, the visibility property defaults to undefined if it's not set when the layer
         // is added, even though the layer is visible by default.  So once the map is loaded, go
@@ -102,7 +101,7 @@ export default function TreeLayerLegend({
         }
       };
 
-      map.on('load', handleMapLoaded);
+      map.once('load', handleMapLoaded);
     }
   }, [map, isMapLoaded]);
 


### PR DESCRIPTION
- Upgrade to mapbox-gl v2.7.0 so we can supply an array of layer IDs when adding the mouseleave handler.  That way, we can use a single handler for all the layers while still getting a mouseleave when the mouse moves over a popup.
- Fix the order of calls in map.onload to ensure the public.treedata source gets added before the map layers get rendered.
- Don't render any Map children until the map is loaded, and render MapLayers first.
- Move the container in the portal components into state, so that when the container is created in response to an onAdd() call from the map, a re-render will be triggered.
