### PR TITLE
Clean up from side panel PRs

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -2,10 +2,10 @@ import React, { Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
+import ErrorBoundary from '@/components/ErrorBoundary/ErrorBoundary';
 import Auth0ProviderWithRedirect from '@/components/Auth/Auth0ProviderWithRedirect';
 import Header from '@/components/Header';
 import Mapper from '@/pages/mapper/Mapper';
-import MapLayout from '@/pages/map/MapLayout';
 import About from '@/pages/about/About';
 import Privacy from '@/pages/privacy/Privacy';
 import License from '@/pages/license/License';
@@ -17,8 +17,10 @@ import RedirectWithHash from '@/components/Auth/RedirectWithHash';
 import Loading from '@/components/Auth/Loading';
 import './App.css';
 
-// Lazy-load the data page, so that we only load the large JSON files it uses if needed.
+// Lazy-load the data page, so that we only load the large JSON files it uses if needed.  Also
+// lazy-load the /map route, so that it doesn't impact the default route.
 const Data = React.lazy(() => import(/* webpackChunkName: "Data" */ '@/pages/data/Data'));
+const MapLayout = React.lazy(() => import(/* webpackChunkName: "MapLayout" */ '@/pages/map/MapLayout'));
 
 // Create a client for react-query calls.  Don't automatically refetch the data when the window is
 // focused since it's not changing that frequently.
@@ -39,30 +41,32 @@ const theme = createTheme({
 
 function App() {
   return (
-    <ThemeProvider theme={theme}>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter basename="/">
-          <Auth0ProviderWithRedirect>
-            <Header />
-            <Suspense fallback={<Loading />}>
-              <Routes>
-                <Route path="/" element={<Mapper />} />
-                <Route path="/treemap" element={<Mapper />} />
-                <Route path="/map" element={<MapLayout />} />
-                <Route path="/userprofile" element={<RequireAuth component={UserProfile} />} />
-                <Route path="/about" element={<About />} />
-                <Route path="/privacy" element={<Privacy />} />
-                <Route path="/license" element={<License />} />
-                <Route path="/contact" element={<Contact />} />
-                <Route path="/data" element={<Data />} />
-                <Route path="/go" element={<RedirectWithHash param="to" />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </Suspense>
-          </Auth0ProviderWithRedirect>
-        </BrowserRouter>
-      </QueryClientProvider>
-    </ThemeProvider>
+    <ErrorBoundary>
+      <ThemeProvider theme={theme}>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter basename="/">
+            <Auth0ProviderWithRedirect>
+              <Header />
+              <Suspense fallback={<Loading />}>
+                <Routes>
+                  <Route path="/" element={<Mapper />} />
+                  <Route path="/treemap" element={<Mapper />} />
+                  <Route path="/map" element={<MapLayout />} />
+                  <Route path="/userprofile" element={<RequireAuth component={UserProfile} />} />
+                  <Route path="/about" element={<About />} />
+                  <Route path="/privacy" element={<Privacy />} />
+                  <Route path="/license" element={<License />} />
+                  <Route path="/contact" element={<Contact />} />
+                  <Route path="/data" element={<Data />} />
+                  <Route path="/go" element={<RedirectWithHash param="to" />} />
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </Suspense>
+            </Auth0ProviderWithRedirect>
+          </BrowserRouter>
+        </QueryClientProvider>
+      </ThemeProvider>
+    </ErrorBoundary>
   );
 }
 

--- a/client/src/components/Auth/Loading.js
+++ b/client/src/components/Auth/Loading.js
@@ -1,28 +1,35 @@
 import React from 'react';
-import { Grid, Typography } from '@mui/material';
+import { Fade, Grid, Typography } from '@mui/material';
 import Footer from '@/components/Footer';
 import treeIcon from '@/assets/images/addtree/tree16.svg';
 
+// Wrap the loading text and image in a fade transition so that it doesn't appear and then get
+// immediately replaced with the lazy-loaded component, which can cause a noticeable flicker.
 const Loading = () => (
-  <Grid container
-    justifyContent="center"
-    alignItems="center"
-    direction="column"
-    sx={{ height: '100vh' }}
+  <Fade in
+    timeout={1500}
+    easing="cubic-bezier(0.7, 0, 0.84, 0)"
   >
-    <Grid item>
-      <img src={treeIcon}
-        alt="Loading..."
-        style={{ height: '100px' }}
-      />
+    <Grid container
+      justifyContent="center"
+      alignItems="center"
+      direction="column"
+      sx={{ height: '100vh' }}
+    >
+      <Grid item>
+        <img src={treeIcon}
+          alt="Loading..."
+          style={{ height: '100px' }}
+        />
+      </Grid>
+      <Grid item>
+        <Typography variant="h3" sx={{ mt: 2 }}>
+          Loading...
+        </Typography>
+      </Grid>
+      <Footer />
     </Grid>
-    <Grid item>
-      <Typography variant="h3" sx={{ mt: 2 }}>
-        Loading...
-      </Typography>
-    </Grid>
-    <Footer />
-  </Grid>
+  </Fade>
 );
 
 export default Loading;

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -16,3 +16,5 @@
     <div class="root"></div>
   </body>
 </html>
+
+<!-- Built at <%= htmlWebpackPlugin.options.buildTime %> -->

--- a/client/src/pages/map/Map/MapboxControlPortal.js
+++ b/client/src/pages/map/Map/MapboxControlPortal.js
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 
+// MapboxControlPortal bridges Mapbox and React.  It manages adding/removing a control to/from the
+// map, and creates a container div into which React will render the child components.
 export default function MapboxControlPortal({ map, position, children }) {
   const [container, setContainer] = useState(null);
   // Use a ref to store an instance of the IControl interface from Mapbox:

--- a/client/src/pages/map/MapLayout.js
+++ b/client/src/pages/map/MapLayout.js
@@ -1,15 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
-import {
-  Box, styled, useMediaQuery, useTheme,
-} from '@mui/material';
+import { Box, styled } from '@mui/material';
 import { useTreeQuery } from '@/api/queries';
 import ErrorBoundary from '@/components/ErrorBoundary/ErrorBoundary';
+import ScrollableDialog from '@/components/ScrollableDialog/ScrollableDialog';
+import { useIsMobile } from '@/pages/map/NewTree/utilities';
 import DetailsDrawer from './DetailsDrawer';
 import Map from './Map/Map';
 import TreeDetailsPanel from './TreeDetails/TreeDetailsPanel';
 import NewTreePanel from './NewTree/NewTreePanel';
 import { useNewTree, NewTreeProvider } from './NewTree/useNewTree';
-import ScrollableDialog from '@/components/ScrollableDialog/ScrollableDialog';
 
 const drawerWidth = 350;
 
@@ -46,9 +45,8 @@ function MapLayout() {
   const { newTreeState } = useNewTree();
   const mapContainerRef = useRef(null);
   const { data: currentTreeData, isError: isTreeQueryError } = useTreeQuery({ id: currentTreeId });
-  const theme = useTheme();
   // Use a full-screen dialog on smaller screens instead of the drawer.
-  const drawerEnabled = !useMediaQuery(theme.breakpoints.down('sm'));
+  const drawerEnabled = !useIsMobile();
   const drawerOpen = !!currentTreeId || newTreeState.isPanelOpen;
   const container = drawerEnabled
     ? DetailsDrawer

--- a/client/src/pages/map/NewTree/Crosshairs.js
+++ b/client/src/pages/map/NewTree/Crosshairs.js
@@ -20,7 +20,7 @@ export const Crosshairs = (props) => (
         }
 
         .dot {
-          fill: currentColor;
+          fill: orange;
           stroke: none;
         }
       `}

--- a/client/src/pages/map/NewTree/Marker.js
+++ b/client/src/pages/map/NewTree/Marker.js
@@ -5,9 +5,15 @@ import { AddButton, TrackingToggle } from './MarkerButtons';
 import { TooltipBottom, TooltipTop } from '@/components/Tooltip';
 
 const circleSize = 70;
+const outerBorderSize = 2;
 
 const Container = styled(Box)`
   text-align: center;
+`;
+
+const OuterBorder = styled('div')`
+  border: ${outerBorderSize}px solid white;
+  border-radius: 50%;
 `;
 
 const OuterCircle = styled('div')(({ theme }) => `
@@ -38,8 +44,8 @@ const InnerCircle = styled('div')(({ theme }) => `
 `);
 
 const Target = styled(Crosshairs)(({ theme }) => `
-  width: 35px;
-  height: 35px;
+  width: ${circleSize / 2}px;
+  height: ${circleSize / 2}px;
   color: ${theme.palette.primary.main};
 `);
 
@@ -50,15 +56,17 @@ const Toolbar = styled(Box)`
   justify-content: space-between;
 `;
 
-export default function Marker({ tracking, onPlantClick, onTrackingChange }) {
+export function Marker({ tracking, onPlantClick, onTrackingChange }) {
   return (
     <Container>
       <TooltipTop title="Drag to the location for the new tree">
-        <OuterCircle>
-          <InnerCircle>
-            <Target />
-          </InnerCircle>
-        </OuterCircle>
+        <OuterBorder>
+          <OuterCircle>
+            <InnerCircle>
+              <Target />
+            </InnerCircle>
+          </OuterCircle>
+        </OuterBorder>
       </TooltipTop>
       <Toolbar>
         <TooltipBottom
@@ -82,3 +90,7 @@ export default function Marker({ tracking, onPlantClick, onTrackingChange }) {
     </Container>
   );
 }
+
+// Calculate the offset from the top-left of the marker to the center of the target.  Adding 1px
+// seems to align the planted tree with the crosshairs better.
+export const markerOffset = (circleSize + 2 * outerBorderSize) / 2 + 1;

--- a/client/src/pages/map/NewTree/MarkerButtons.js
+++ b/client/src/pages/map/NewTree/MarkerButtons.js
@@ -2,16 +2,20 @@ import React, { forwardRef } from 'react';
 import { Checkbox, IconButton, styled } from '@mui/material';
 import { Add, LocationOn, LocationOnOutlined } from '@mui/icons-material';
 
+// When the mouse is over the button or clicks it, we don't want the map to hear those events, so
+// it doesn't show a popup for the tree or details in the drawer.
+const stopPropagation = (event) => event.stopPropagation();
+
 // These styles will be used for both the IconButton and Checkbox below.
 const styles = `
   padding: 3px;
   border-radius: 50%;
-  color: rgba(255, 255, 255, .8);
-  background: rgba(0, 0, 0, .25);
+  color: rgba(255, 255, 255, .9);
+  background: rgba(0, 0, 0, .45);
 
   &:hover {
-    color: rgba(255, 255, 255, .9);
-    background: rgba(0, 0, 0, .35);
+    color: rgba(255, 255, 255, 1);
+    background: rgba(0, 0, 0, .6);
   }
 
   & .MuiSvgIcon-root {
@@ -26,6 +30,7 @@ const StyledButton = styled(IconButton)(styles);
 const AddButton = forwardRef((props, ref) => (
   <StyledButton
     ref={ref}
+    onMouseMove={stopPropagation}
     {...props}
   >
     <Add />
@@ -38,11 +43,10 @@ const TrackingToggle = forwardRef((props, ref) => (
   <StyledCheckbox
     ref={ref}
     icon={<LocationOnOutlined />}
-    // Force the checked icon to be white, since it will default to the primary color.
+    // Force the checked icon to be white, since otherwise it will default to the `primary` color.
     checkedIcon={<LocationOn sx={{ color: 'white' }} />}
-    // In case the tracking button is over a tree circle, stop event propagation so that the map
-    // doesn't hear the click and open the details drawer for that tree.
-    onClick={(event) => event.stopPropagation()}
+    onClick={stopPropagation}
+    onMouseMove={stopPropagation}
     {...props}
   />
 ));

--- a/client/src/pages/map/NewTree/NewTree.js
+++ b/client/src/pages/map/NewTree/NewTree.js
@@ -3,16 +3,16 @@ import { useAuth0 } from '@auth0/auth0-react';
 import { styled, ToggleButton } from '@mui/material';
 import useAuthUtils from '@/components/Auth/useAuthUtils';
 import { useCreateTreeDataMutation, useUserMutation } from '@/api/queries';
-import { MapboxMarkerPortal } from '@/pages/map/Map/MapboxMarkerPortal';
+import { useIsMobile } from '@/pages/map/NewTree/utilities';
+import MapboxMarkerPortal from '@/pages/map/Map/MapboxMarkerPortal';
 import PlusIconPath from '@/assets/images/addtree/plus2.svg';
-import { isMobile } from './utilities';
 import { useNewTree } from './useNewTree';
 import { useGeolocation } from './useGeolocation';
-import Marker from './Marker';
+import { Marker, markerOffset } from './Marker';
 
 const markerOptions = {
   anchor: 'top-left',
-  offset: [-35, -35],
+  offset: [-markerOffset, -markerOffset],
   draggable: true,
 };
 
@@ -46,7 +46,7 @@ const PlantButton = styled(ToggleButton)`
 export default function NewTree({ map }) {
   const { user, isAuthenticated } = useAuth0();
   const { loginToCurrentPage } = useAuthUtils();
-  const [tracking, setTracking] = useState(isMobile);
+  const [tracking, setTracking] = useState(useIsMobile());
   const [markerStartCoords, setMarkerStartCoords] = useState(null);
   const mutateUser = useUserMutation();
   const mutateTreeData = useCreateTreeDataMutation();

--- a/client/src/pages/map/NewTree/utilities.js
+++ b/client/src/pages/map/NewTree/utilities.js
@@ -1,3 +1,7 @@
+import { useMediaQuery } from '@mui/material';
+
 export const randomInteger = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 
-export const isMobile = window.innerWidth <= 768;
+// Pass noSsr: true so that useMediaQuery() doesn't return false initially, which it does to
+// accommodate SSR.
+export const useIsMobile = () => useMediaQuery((theme) => theme.breakpoints.down('sm'), { noSsr: true });

--- a/client/src/pages/map/TreeDetails/CoreData.js
+++ b/client/src/pages/map/TreeDetails/CoreData.js
@@ -1,32 +1,64 @@
 /* eslint-disable react/jsx-one-expression-per-line */
-import React from 'react';
-import { Link } from '@mui/material';
+import React, { useState } from 'react';
 import format from 'date-fns/format';
+import { useAuth0 } from '@auth0/auth0-react';
+import useAuthUtils from '@/components/Auth/useAuthUtils';
+import CoreDataDialog from '@/pages/map/TreeDetails/CoreDataDialog';
+import AdoptLikeCheckboxes from '@/pages/map/TreeDetails/AdoptLikeCheckboxes';
 
-export default function CoreData({
-  treeData, vacant,
-}) {
+export default function CoreData({ treeData, vacant }) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { isAuthenticated } = useAuth0();
+  const { loginToCurrentPage } = useAuthUtils();
   const {
-    common, scientific, genus, datePlanted, dbh, height,
+    id, common, scientific, genus, datePlanted, dbh, height,
   } = treeData;
   const wikipediaLink = `https://en.wikipedia.org/wiki/${scientific}`;
   // format() will throw an exception if datePlanted is undefined, so check it first.
   const planted = datePlanted && format(new Date(datePlanted), 'MMMM d, yyyy');
 
+  const closeDialog = () => setIsDialogOpen(false);
+
+  const handleEditClick = () => {
+    if (!isAuthenticated) {
+      loginToCurrentPage();
+    } else {
+      setIsDialogOpen(true);
+    }
+  };
+
   return (
-    <div className="text-left">
-      <h1>
-        {common}
-      </h1>
-      {!vacant && (
-        <div>
-          <h2><a href={wikipediaLink} name={wikipediaLink} target="_blank" rel="noreferrer">{scientific}</a></h2>
-          {(scientific !== genus) && <h2>{genus}</h2>}
-          {height && <h5>Height: {height}</h5>}
-          {dbh && <h5>DBH: {dbh}</h5>}
-          {datePlanted && <h5>Planted: {planted}</h5>}
-        </div>
+    <>
+      <div className="text-left">
+        <h1>
+          {common}
+        </h1>
+        {!vacant && (
+          <div>
+            <h2><a href={wikipediaLink} name={wikipediaLink} target="_blank" rel="noreferrer">{scientific}</a></h2>
+            {(scientific !== genus) && <h2>{genus}</h2>}
+            {height && <h5>Height: {height}</h5>}
+            {dbh && <h5 title="Diameter at breast height">DBH: {dbh}</h5>}
+            {datePlanted && <h5>Planted: {planted}</h5>}
+          </div>
+        )}
+      </div>
+
+      <AdoptLikeCheckboxes
+        currentTreeId={id}
+        common={common}
+        edit={handleEditClick}
+      />
+
+      {isDialogOpen && (
+        <CoreDataDialog
+          open={isDialogOpen}
+          currentTreeId={id}
+          treeData={treeData}
+          onConfirm={closeDialog}
+          onCancel={closeDialog}
+        />
       )}
-    </div>
+    </>
   );
 }

--- a/client/src/pages/map/TreeDetails/CoreDataDialog.js
+++ b/client/src/pages/map/TreeDetails/CoreDataDialog.js
@@ -21,8 +21,8 @@ function noNulls(object) {
 
 const vacantPattern = /vacant/i;
 
-export default function TreeEditDialog({
-  currentTreeId, treeData, showEditDialog, setShowEditDialog,
+export default function CoreDataDialog({
+  open, currentTreeId, treeData, onConfirm, onCancel,
 }) {
   const { user = {} } = useAuth0();
   const mutateTreeData = useTreeDataMutation();
@@ -82,19 +82,17 @@ export default function TreeEditDialog({
       }
     }
 
-    setShowEditDialog(false);
+    onConfirm(formData);
   };
-
-  const handleCancel = () => setShowEditDialog(false);
 
   const handleError = (errorLog, e) => console.error('errors, e', errorLog, e);
 
   return (
     <FormScrollableDialog
       title="Edit Tree"
-      open={showEditDialog}
+      open={open}
       onConfirm={handleConfirm}
-      onCancel={handleCancel}
+      onCancel={onCancel}
       onError={handleError}
       fullScreen={false}
       maxWidth="xs"

--- a/client/src/pages/map/TreeDetails/TreeDetailsPanel.js
+++ b/client/src/pages/map/TreeDetails/TreeDetailsPanel.js
@@ -1,10 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Alert } from '@mui/material';
-import { useAuth0 } from '@auth0/auth0-react';
-import useAuthUtils from '@/components/Auth/useAuthUtils';
 import CoreData from './CoreData';
-import CoreDataDialog from './CoreDataDialog';
-import AdoptLikeCheckboxes from './AdoptLikeCheckboxes';
 import MaintainTree from './MaintainTree';
 import RemoveTree from './RemoveTree';
 import Health from './Health';
@@ -15,9 +11,6 @@ import Info from './Info';
 export default function TreeDetailsPanel({
   Container, drawerWidth, currentTreeData, currentTreeId, setCurrentTreeId, isTreeQueryError,
 }) {
-  const [showEditDialog, setShowEditDialog] = useState(false);
-  const { isAuthenticated } = useAuth0();
-  const { loginToCurrentPage } = useAuthUtils();
   // If a tree is selected but there was an error in fetching the data, show an error message.
   // Otherwise, show a blank panel while waiting for the data.
   const noDataChild = currentTreeId && isTreeQueryError
@@ -37,15 +30,6 @@ export default function TreeDetailsPanel({
 
   const handleClose = () => setCurrentTreeId(null);
 
-  // TODO: this should be handled by CoreData
-  const handleEditClick = () => {
-    if (!isAuthenticated) {
-      loginToCurrentPage();
-    } else {
-      setShowEditDialog(!showEditDialog);
-    }
-  };
-
   return (
     <Container
       title="Tree Details"
@@ -59,21 +43,6 @@ export default function TreeDetailsPanel({
             <CoreData
               treeData={currentTreeData}
               vacant={vacant}
-            />
-
-            {showEditDialog && (
-              <CoreDataDialog
-                currentTreeId={currentTreeId}
-                treeData={currentTreeData}
-                showEditDialog={showEditDialog}
-                setShowEditDialog={setShowEditDialog}
-              />
-            )}
-
-            <AdoptLikeCheckboxes
-              currentTreeId={currentTreeId}
-              common={common}
-              edit={handleEditClick}
             />
 
             {!vacant && (

--- a/client/src/util/config.js
+++ b/client/src/util/config.js
@@ -1,12 +1,14 @@
 /* eslint-disable max-len */
 
+// Default env to localserver in case hostname doesn't match anything, which it may not if we're
+// trying to access the local dev server from another machine using the host's address.
 const env = {
   'www.waterthetrees.com': 'prod',
   'waterthetrees.com': 'prod',
   'dev.waterthetrees.com': 'dev',
   'blue.waterthetrees.com': 'blue',
   localhost: 'localserver',
-}[window.location.hostname];
+}[location.hostname] || 'localserver';
 
 const mapboxAccessToken = {
   // key: 'pk.eyJ1IjoiMTAwa3RyZWVzIiwiYSI6ImNrNzFqdWFpeDA2cDQzbnF3amtoM2xrdzQifQ.XEXk0ePKHFgN8rp1YHNn4w'

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "webpack-dev-server": "^4.7.4"
   },
   "scripts": {
+    "postinstall": "npm run build:data",
     "lint": "npm run lint:js || npm run lint:css",
     "lint:css": "stylelint \"client/src/**/*.scss\"",
     "lint:js": "eslint --ignore-path .gitignore --ignore-pattern \"!**/.*\" .",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -80,6 +80,9 @@ module.exports = (env) => {
       new HtmlWebPackPlugin({
         template: './client/src/index.html',
         filename: './index.html',
+        minify: false,
+          // add a timestamp that's injected into an HTML comment
+        buildTime: new Date().toISOString()
       }),
       new MiniCssExtractPlugin({
         filename: '[name].css',


### PR DESCRIPTION
- Convert MapboxMarkerPortal to functional component.
- Lazy-load the /map route.
- Wrap the app in an ErrorBoundary component.
- Fade in the loading page content so there's not a flicker of the tree image before the /map route loads.
- Make handling of edited notes work like the health slider and fix a bug where edited notes didn't show after a reload.
- Create useIsMobile hook using media query.
- Update docs and vars in queries.js.
- Make the marker buttons darker and add a white border to the outside it shows up better on a complicated background.
- Suppress mouse events on the buttons so the map doesn't hear them and show tooltips.
- Show an orange dot in the middle of the crosshairs.
- Clean up TreeDetailsPanel and CoreData.
- Export a marker offset value from Marker.js so NewTree can adjust where the tree is planted based on the marker location.
- Add postinstall script to run build:data so that the JS files are created in src/data/dist when the repo is created.
- Add build timestamp to bottom of index.html.

The tweaked planting marker looks like this:

![image](https://user-images.githubusercontent.com/61631/155874292-cb958297-7635-4949-b6b1-08f4b4e85513.png)
