### PR TITLE
download-links

### DIFF
--- a/client/src/pages/Tree/AdoptLikeCheckboxes.js
+++ b/client/src/pages/Tree/AdoptLikeCheckboxes.js
@@ -80,7 +80,6 @@ export default function AdoptLikeCheckboxes({
         scientific: currentTreeData.scientific
         || currentTreeData.genus,
         city: currentTreeData.city || currentTreeData.sourceId,
-        url: currentTreeData.download,
         volunteer: user.nickname,
         health: currentTreeData.health || 'fair',
       });

--- a/client/src/pages/Tree/Tree.js
+++ b/client/src/pages/Tree/Tree.js
@@ -7,10 +7,12 @@ import TreeHealth from './TreeHealth';
 import TreeNotes from './TreeNotes';
 import TreeHistory from './TreeHistory';
 import TreeInfo from './TreeInfo';
+import TreeLinks from './TreeLinks';
 
 export default function Tree({
   map,
-  TreeDetailsContainer, drawerWidth, currentTreeData, currentTreeId, setCurrentTreeId, isTreeQueryError,
+  TreeDetailsContainer, drawerWidth, currentTreeData,
+  currentTreeId, setCurrentTreeId, isTreeQueryError,
 }) {
   // If a tree is selected but there was an error in fetching the data, show an error message.
   // Otherwise, show a blank panel while waiting for the data.
@@ -80,6 +82,10 @@ export default function Tree({
             />
 
             <TreeInfo
+              currentTreeData={currentTreeData}
+            />
+
+            <TreeLinks
               currentTreeData={currentTreeData}
             />
 

--- a/client/src/pages/Tree/TreeHealth.js
+++ b/client/src/pages/Tree/TreeHealth.js
@@ -83,7 +83,6 @@ export default function TreeHealth({ currentTreeData, isTreeQueryError }) {
         setHealthSaveAlert('saving...');
         mutateCreateTreeData.mutate({
           ...currentTreeData,
-          url: currentTreeData.download,
           health: newHealth,
           scientific: currentTreeData.scientific
           || currentTreeData.species,

--- a/client/src/pages/Tree/TreeInfo.js
+++ b/client/src/pages/Tree/TreeInfo.js
@@ -1,8 +1,10 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/jsx-props-no-spreading */
 /* eslint-disable no-return-assign */
 /* eslint-disable no-param-reassign */
 import React from 'react';
 import {
-  TableRow, TableCell, Link, Box,
+  TableRow, TableCell,
 } from '@mui/material';
 import Section from '@/components/Section/Section';
 import TreeTable from './TreeTable';
@@ -26,9 +28,6 @@ const infoKeys = [
   ['idReference', 'Ref #'],
   'id',
   'sourceid',
-  'download',
-  'url',
-  'info',
   'count',
   'treelocationcount',
 ].map((treeRow) => (Array.isArray(treeRow)
@@ -58,20 +57,11 @@ export default function TreeInfo({ currentTreeData }) {
           <TableRows key={label} label={label} value={value} />
         ))}
       </TreeTable>
-      <Box sx={{ my: 1, textAlign: 'right' }}>
-        <Link
-          href="https://standards.opencouncildata.org/#/trees"
-          underline="hover"
-        >
-          Open Council Data Standards
-        </Link>
-      </Box>
     </Section>
   );
 }
 
 const TableRows = ({ label, value }) => (
-
   <TableRow key={label}>
     <TableCell sx={{ pl: 0, fontWeight: 'bold' }}>{label}</TableCell>
     <TableCell>{value}</TableCell>

--- a/client/src/pages/Tree/TreeLinks.js
+++ b/client/src/pages/Tree/TreeLinks.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/destructuring-assignment */
+/* eslint-disable react/jsx-props-no-spreading */
+/* eslint-disable no-return-assign */
+/* eslint-disable no-param-reassign */
+import React from 'react';
+import { Link, Box } from '@mui/material';
+import Section from '@/components/Section/Section';
+
+export default function TreeLinks({ currentTreeData }) {
+  const links = [
+    {
+      url: currentTreeData.download && currentTreeData.download.url,
+      label: `Download ${currentTreeData.city} Data`,
+    },
+    {
+      url: currentTreeData.info,
+      label: `Download ${currentTreeData.city} Info`,
+    },
+    {
+      url: 'https://standards.opencouncildata.org/#/trees',
+      label: 'Open Council Data Standards',
+    },
+  ];
+
+  return (
+    <Section
+      title="Links"
+    >
+      {links.map((link) => (
+        <Anchor key={link.label} label={link.label} url={link.url} />
+      ))}
+    </Section>
+  );
+}
+
+const Anchor = ({ url, label }) => (
+  <Box sx={{ my: 1, textAlign: 'left' }}>
+    {url && (
+      <Link href={url} target="_blank" rel="noopener" underline="always">
+        {label}
+      </Link>
+    )}
+  </Box>
+);


### PR DESCRIPTION
Adds download links to another links section rather than info section.

We should save the downloads in the city table rather than treedata and pull it with the initial city fetch.
The url in treedata should be for the tree url or just remove it.

for now this is really just a PR for the Links section as that is useful going forward.