### PR TITLE
Share trees by URL

### DIFF
--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -101,8 +101,8 @@ export default function Map({
         zoom: 10,
         maxZoom: 18.5,
         minZoom: 2,
-        // Pass true to update the browser URL hash with the current zoom and lat/long of the map.
-        hash: true,
+        // Update the browser URL hash with the current zoom and lat/long of the map.
+        hash: 'pos',
       });
 
       // Add the navigation controls to the map.
@@ -129,6 +129,7 @@ export default function Map({
             return;
           }
 
+          const hashParams = new URLSearchParams(window.location.hash.slice(1));
           const [feature] = mapboxMap.queryRenderedFeatures([x, y], { layers: layerIDs });
 
           if (feature) {
@@ -146,12 +147,15 @@ export default function Map({
             }
 
             setCurrentTreeId(id);
-
+            hashParams.set('id', id);
             mapboxMap.getCanvas().style.cursor = 'pointer';
           } else {
             // This click was on a blank part of the map, so clear the selection.
             setCurrentTreeId(null);
+            hashParams.delete('id');
           }
+
+          window.location.hash = decodeURIComponent(hashParams.toString());
         });
 
         // Unlike the click handler above, we want to get mousemove/leave events only for features

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -40,8 +40,9 @@ const MapContainer = styled('main', { shouldForwardProp: (prop) => prop.indexOf(
 );
 
 function MapLayout() {
+  const hashParams = new URLSearchParams(window.location.hash.slice(1));
+  const [currentTreeId, setCurrentTreeId] = useState(hashParams.get('id'));
   const [map, setMap] = useState(null);
-  const [currentTreeId, setCurrentTreeId] = useState(null);
   const [mapSelectionEnabled, setMapSelectionEnabled] = useState(true);
   const { newTreeState } = useNewTree();
   const mapContainerRef = useRef(null);
@@ -116,6 +117,17 @@ function MapLayout() {
   useEffect(() => {
     setMapSelectionEnabled(!newTreeState.isDragging);
   }, [newTreeState.isDragging]);
+
+  // On initial page load, if there is a tree id in the url as
+  // a hash param, move to that tree on the map.
+  useEffect(() => {
+    if (map && currentTreeId) {
+      map.flyTo({
+        center: [currentTreeData.lng, currentTreeData.lat],
+        zoom: 17,
+      });
+    }
+  }, [map]);
 
   return (
     <Box sx={{ display: 'flex' }}>


### PR DESCRIPTION
When a tree is selected, we now add the tree's id to the URL as a hash parameter. As a result, we can save and share trees through their URL.

https://user-images.githubusercontent.com/6326660/164611502-a6fa0b1c-095c-4c19-aada-3f0db69d0a6a.mov
