### PR TITLE
Share trees by URL

### DIFF
--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -121,11 +121,19 @@ function MapLayout() {
   // On initial page load, if there is a tree id in the url as
   // a hash param, move to that tree on the map.
   useEffect(() => {
-    if (map && currentTreeId) {
+    if (!map) {
+      return;
+    }
+
+    if (currentTreeData) {
       map.flyTo({
         center: [currentTreeData.lng, currentTreeData.lat],
         zoom: 17,
       });
+    } else {
+      setCurrentTreeId(null);
+      hashParams.delete('id');
+      window.location.hash = decodeURIComponent(hashParams.toString());
     }
   }, [map]);
 


### PR DESCRIPTION
I now handle the case when the id in the URL doesn't reference a tree with that id in the database. This might need to be refined later, but the originally desired functionality works and doesn't error out with a wrong id.