### PR TITLE
Fetch tree images from database tree data

### DIFF
--- a/client/src/components/TreeUtil/TreeNameAndSize.js
+++ b/client/src/components/TreeUtil/TreeNameAndSize.js
@@ -10,7 +10,14 @@ function getNames(treeList, name, firstItem) {
   // Otherwise, React will complain about duplicate keys in the menu.  Sort the trees by the
   // different fields before extracting the strings, so that the sort function can access the
   // per-tree lowercase sort fields.
-  return firstItem.concat([...new Set(treeList.sort(sortTreesBy[name]).map((tree) => tree[name]))]);
+  return firstItem.concat([
+    ...new Set(
+      treeList
+        .filter((tree) => !['', 'vacant site'].includes(tree[name].toLowerCase()))
+        .sort(sortTreesBy[name])
+        .map((tree) => tree[name]),
+    ),
+  ]);
 }
 
 // Adjust the adornment label so it aligns with the input placeholder.

--- a/client/src/data/sortTreesBy.js
+++ b/client/src/data/sortTreesBy.js
@@ -1,18 +1,14 @@
 function createTreeSorter(name) {
   const index = { common: 0, scientific: 1, genus: 2 }[name];
+  const collator = new Intl.Collator('en', {
+    usage: 'sort',
+    sensitivity: 'base',
+    ignorePunctuation: true,
+    numeric: true,
+    caseFirst: 'upper',
+  });
 
-  return function(a, b) {
-    const aName = a.sort[index];
-    const bName = b.sort[index];
-
-    if (aName === bName) {
-      return 0;
-    } else if (aName < bName) {
-      return -1;
-    } else {
-      return 1;
-    }
-  }
+  return (a, b) => collator.compare(a.sort[index], b.sort[index]);
 }
 
 export default {

--- a/data/build.js
+++ b/data/build.js
@@ -161,8 +161,7 @@ jsonFiles.forEach((filename) => {
   // Combine the trees into one deduped list, normalizing the names.
   data.forEach(({ common, scientific, genus }) => {
     const commonTitleCase = toTitleCase(common);
-    const lcNames = [common, scientific, genus]
-      .map((name) => name.toLowerCase().replace(/[^\w\s]/g, ''));
+    const lcNames = [common, scientific, genus].map(normalizeNames);
     const key = lcNames.join('');
 
     // Ignore dupes in the data, as well as things that aren't trees, like fungus and rainbow trout.
@@ -172,9 +171,9 @@ jsonFiles.forEach((filename) => {
       && !ignoreScientificPattern.test(scientific)
     ) {
       trees.push({
-        common: commonTitleCase,
-        scientific,
-        genus,
+        common: replaceIrregularNames(commonTitleCase),
+        scientific: replaceIrregularNames(scientific),
+        genus: replaceIrregularNames(genus),
         // Store the lowercased names on each tree, so that we can sort by those strings.  They
         // don't include non-letter characters, so names like `"Ohi" A Lehua` won't get sorted to
         // the front of the list.
@@ -184,6 +183,23 @@ jsonFiles.forEach((filename) => {
     }
   });
 });
+
+function normalizeNames(name) {
+  if (!name) {
+    return null;
+  }
+
+  const normalized = name
+    .normalize('NFD')
+    .toLowerCase()
+    .replace(/[^\w\s]/g, '');
+
+  return normalized || null;
+}
+
+function replaceIrregularNames(name) {
+  return name === '\b' ? '' : name;
+}
 
 async function buildImagesMap(trees) {
   const scientificNames = trees.map((tree) => tree.scientific);

--- a/data/json/databaseTrees.json
+++ b/data/json/databaseTrees.json
@@ -1,0 +1,10909 @@
+{
+  "data": [
+    {
+      "common": "\b",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia "
+    },
+    {
+      "common": "\b",
+      "scientific": "Laurus nobilis ?Saratoga? Saratoga Laurel",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Acacia",
+      "scientific": "Acacia species",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia, Bailey",
+      "scientific": "Acacia baileyana",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia, Black",
+      "scientific": "Acacia melanoxylon",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia, Shoestring",
+      "scientific": "Acacia stenophylla",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia: Silver Wattle",
+      "scientific": "Acacia decurrens",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia: Silver Wattle",
+      "scientific": "Acacia decurrens",
+      "genus": "Acacia decurrens"
+    },
+    {
+      "common": "ACACIA SPECIES",
+      "scientific": "Acacia spp.",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia Spp",
+      "scientific": "Acacia spp",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Acacia Spp",
+      "scientific": "Acacia spp",
+      "genus": "Acacia spp"
+    },
+    {
+      "common": "Açaí Palm",
+      "scientific": "Euterpe oleracea",
+      "genus": "Euterpe"
+    },
+    {
+      "common": "ACCOLADE ELM",
+      "scientific": "Ulmus Morton",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Acerola",
+      "scientific": "Malpighia emarginata",
+      "genus": "Malpighia"
+    },
+    {
+      "common": "Acer rubrum 'October Glory'",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Afghan pine",
+      "scientific": "Pinus eldarica",
+      "genus": "Pinus "
+    },
+    {
+      "common": "AFGHAN PINE",
+      "scientific": "Pinus eldarica",
+      "genus": "Pinus "
+    },
+    {
+      "common": "African fern pine",
+      "scientific": "Podocarpus gracilior",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "African fern-pine",
+      "scientific": "Podocarpus gracilior",
+      "genus": "Afrocarpus"
+    },
+    {
+      "common": "African Fern Pine",
+      "scientific": "Afrocarpus gracilior",
+      "genus": "Afrocarpus "
+    },
+    {
+      "common": "AFRICAN RED ALDER",
+      "scientific": "Cunonia capensis",
+      "genus": "Cunonia "
+    },
+    {
+      "common": "African sumac",
+      "scientific": "Rhus lancea",
+      "genus": "Rhus "
+    },
+    {
+      "common": "African Sumac",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "African Sumac",
+      "scientific": "Rhus lancea",
+      "genus": "Rhus "
+    },
+    {
+      "common": "African Sumac",
+      "scientific": "Rhus lancea",
+      "genus": "Rhus lancea"
+    },
+    {
+      "common": "African Sumac",
+      "scientific": "Searsia lancea",
+      "genus": "Searsia "
+    },
+    {
+      "common": "Afterburner tupelo",
+      "scientific": "Nyssa sylvatica 'David Odom' (Afterburner)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Afterburner tupelo",
+      "scientific": "Nyssa sylvatica 'David Odom' (Afterburner tupelo)",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "Afterburner Tupelo",
+      "scientific": "Nyssa sylvatica Tupelo 'Afterburner' 2 y bud in root bag 15 # container",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "AGAVE",
+      "scientific": "Agave angustifolia Marginata",
+      "genus": "Agave "
+    },
+    {
+      "common": "Agave, Fox Tail",
+      "scientific": "Agave attenuata",
+      "genus": "Agave "
+    },
+    {
+      "common": "Akapuka",
+      "scientific": "Griselinia lucida",
+      "genus": "Griselinia "
+    },
+    {
+      "common": "Akebono Cherry",
+      "scientific": "Akebono Cherry",
+      "genus": "Akebono "
+    },
+    {
+      "common": "Akebono Cherry",
+      "scientific": "Prunus x yedoensis 'Akebono' (cherry)",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Akebono' Cherry",
+      "scientific": "Prunus serrulata 'Akebono'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Akebono' Cherry",
+      "scientific": "Prunus serrulata 'Akebono'",
+      "genus": "Prunus serrulata 'Akebono'"
+    },
+    {
+      "common": "ALBIZIA SPECIES",
+      "scientific": "Albizia spp.",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Alder",
+      "scientific": "Alnus species",
+      "genus": "Alnus "
+    },
+    {
+      "common": "Alder, Italian",
+      "scientific": "Alnus cordata",
+      "genus": "Alnus "
+    },
+    {
+      "common": "Alder, Red",
+      "scientific": "Alnus rubra",
+      "genus": "Alnus "
+    },
+    {
+      "common": "ALDER SPECIES",
+      "scientific": "Alnus spp.",
+      "genus": "Alnus "
+    },
+    {
+      "common": "Alder, White",
+      "scientific": "Alnus rhombifolia",
+      "genus": "Alnus "
+    },
+    {
+      "common": "ALEPPO PINE",
+      "scientific": "Pinus halepensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Algarrobo",
+      "scientific": "Prosopis chilensis",
+      "genus": "Prosopis "
+    },
+    {
+      "common": "Allepo Pine",
+      "scientific": "Pinus halepensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Allepo Pine",
+      "scientific": "Pinus halepensis",
+      "genus": "Pinus halepensis"
+    },
+    {
+      "common": "Almond",
+      "scientific": "Prunus amygdalus",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Almond",
+      "scientific": "Prunus amygdalus",
+      "genus": "Prunus amygdalus"
+    },
+    {
+      "common": "Almond, Sweet",
+      "scientific": "Prunus dulcis",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Aloe, Tree",
+      "scientific": "Aloe arborescens",
+      "genus": "Aloe "
+    },
+    {
+      "common": "American ash",
+      "scientific": "Fraxinus americana 'Autumn Purple'",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "American ash",
+      "scientific": "Fraxinus americana 'Autumn Purple' (American ash)",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "American Ash",
+      "scientific": "Fraxinus americana",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "American Ash",
+      "scientific": "Fraxinus americana",
+      "genus": "Fraxinus americana"
+    },
+    {
+      "common": "American Ash",
+      "scientific": "Fraxinus americana 'Autumn Purple' American Ash",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "American Autumn Purple Ash",
+      "scientific": "Fraxinus americana 'Autumn Purple'",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "American Autumn Purple Ash",
+      "scientific": "Fraxinus americana 'Autumn Purple'",
+      "genus": "Fraxinus americana 'Autumn Purple'"
+    },
+    {
+      "common": "American Chestnut",
+      "scientific": "Castanea dentata",
+      "genus": "Castanea "
+    },
+    {
+      "common": "American elm",
+      "scientific": "Ulmus americana 'Jefferson'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "American elm",
+      "scientific": "\"Ulmus americana 'Jefferson' (American elm)\"",
+      "genus": "\"Ulmus "
+    },
+    {
+      "common": "American elm",
+      "scientific": "Ulmus americana 'Princeton'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "American Elm",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "American Elm",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus americana"
+    },
+    {
+      "common": "American Elm",
+      "scientific": "Ulmus americana 'Colonial Spirit'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "American Elm",
+      "scientific": "Ulmus americana 'New Harmony' (American elm) 10#",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "AMERICAN ELM",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "American Holly",
+      "scientific": "Ilex opaca",
+      "genus": "Ilex "
+    },
+    {
+      "common": "American Holly",
+      "scientific": "Ilex opaca",
+      "genus": "Ilex opaca"
+    },
+    {
+      "common": "AMERICAN PERSIMMON",
+      "scientific": "Diospyros virginiana",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "American Sweet Gum",
+      "scientific": "Liquidambar styraciflua",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "American Sweet Gum",
+      "scientific": "Liquidambar styraciflua",
+      "genus": "Liquidambar styraciflua"
+    },
+    {
+      "common": "AMERICAN SWEETGUM",
+      "scientific": "Liquidambar styraciflua",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "American sycamore",
+      "scientific": "Platanus acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "American sycamore",
+      "scientific": "Platanus occidentalis",
+      "genus": "Platanus "
+    },
+    {
+      "common": "American sycamore",
+      "scientific": "Platanus occidentalis",
+      "genus": "Platanus occidentalis"
+    },
+    {
+      "common": "Amur Maple",
+      "scientific": "Acer ginnela",
+      "genus": "Acer ginnela"
+    },
+    {
+      "common": "Angel trumpet",
+      "scientific": "Brugmansia spp",
+      "genus": "Brugmansia "
+    },
+    {
+      "common": "Angel trumpet",
+      "scientific": "Brugmansia spp",
+      "genus": "Brugmansia spp"
+    },
+    {
+      "common": "Angophora species",
+      "scientific": "Angohpora spp.",
+      "genus": "Angohpora "
+    },
+    {
+      "common": "Apple",
+      "scientific": "Malus species",
+      "genus": "Malus "
+    },
+    {
+      "common": "Apple",
+      "scientific": "Malus sylvestris",
+      "genus": "Malus "
+    },
+    {
+      "common": "Apple, Paradise",
+      "scientific": "Malus pumila",
+      "genus": "Malus "
+    },
+    {
+      "common": "Apple Tree 'Gala'",
+      "scientific": "Malus 'Gala'",
+      "genus": "Malus "
+    },
+    {
+      "common": "Apple Tree 'Gala'",
+      "scientific": "Malus 'Gala'",
+      "genus": "Malus 'Gala'"
+    },
+    {
+      "common": "Apricot",
+      "scientific": "Prunus armeniaca",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Apricot",
+      "scientific": "Prunus armeniaca",
+      "genus": "Prunus armeniaca"
+    },
+    {
+      "common": "APRICOT",
+      "scientific": "Prunus armeniaca",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Arborvitae, Oriental",
+      "scientific": "Platycladus orientalis",
+      "genus": "Platycladus "
+    },
+    {
+      "common": "ARBUTUS SPECIES",
+      "scientific": "Arbutus spp.",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Argentine cedar",
+      "scientific": "Cedrela fissilis",
+      "genus": "Cedrela fissilis"
+    },
+    {
+      "common": "Aristocrat Callery Pear",
+      "scientific": "Pyrus calleryana 'Aristocrat'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Aristocrat Callery Pear",
+      "scientific": "Pyrus calleryana 'Aristocrat'",
+      "genus": "Pyrus calleryana 'Aristocrat'"
+    },
+    {
+      "common": "Aristocrat Pear",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "ARIZONA ASH",
+      "scientific": "Fraxinus velutina",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Arizona Cypress",
+      "scientific": "Cupressus arizonica",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Arizona Cypress",
+      "scientific": "Cupressus arizonica",
+      "genus": "Cupressus arizonica"
+    },
+    {
+      "common": "Armstrong Red Maple",
+      "scientific": "Acer rubrum 'Armstrong'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Armstrong Red Maple",
+      "scientific": "Acer rubrum 'Armstrong'",
+      "genus": "Acer rubrum 'Armstrong'"
+    },
+    {
+      "common": "Arroyo willow",
+      "scientific": "Salix lasiolepis",
+      "genus": "Salix "
+    },
+    {
+      "common": "Arroyo willow",
+      "scientific": "Salix lasiolepis",
+      "genus": "Salix lasiolepis"
+    },
+    {
+      "common": "ARROYO WILLOW",
+      "scientific": "Salix lasiolepis",
+      "genus": "Salix "
+    },
+    {
+      "common": "Ash",
+      "scientific": "Fraxinus oxycarpa",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash",
+      "scientific": "Fraxinus oxycarpa",
+      "genus": "Fraxinus oxycarpa"
+    },
+    {
+      "common": "Ash",
+      "scientific": "Fraxinus species",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Black",
+      "scientific": "Fraxinus nigra",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Caucasian",
+      "scientific": "Fraxinus oxycarpa",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash-colored Eucalyptus",
+      "scientific": "Eucalyptus cinerea",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Ash-colored Eucalyptus",
+      "scientific": "Eucalyptus cinerea",
+      "genus": "Eucalyptus cinerea"
+    },
+    {
+      "common": "Ash, European",
+      "scientific": "Fraxinus excelsior",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Flowering",
+      "scientific": "Fraxinus ornus",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Green",
+      "scientific": "Fraxinus pennsylvanica",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Modesto",
+      "scientific": "Fraxinus velutina 'Modesto'",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Oregon",
+      "scientific": "Fraxinus latifolia",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Raywood",
+      "scientific": "Fraxinus angustifolia",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "ASH SPECIES",
+      "scientific": "Fraxinus spp.",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash Spp",
+      "scientific": "Fraxinus spp",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash Spp",
+      "scientific": "Fraxinus spp",
+      "genus": "Fraxinus spp"
+    },
+    {
+      "common": "Ash, Tropical",
+      "scientific": "Fraxinus uhdei",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, Velvet",
+      "scientific": "Fraxinus velutina",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Ash, White",
+      "scientific": "Fraxinus americana",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "ASIAN BAYBERRY",
+      "scientific": "Nageia nagi",
+      "genus": "Nageia "
+    },
+    {
+      "common": "Asian Pear '20th Century'",
+      "scientific": "Pyrus pyrifolia '20th Century'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Asian Pear 'Sainseiki'",
+      "scientific": "Pyrus pyrifolia 'Sainseiki'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "ASPHALTED WELL",
+      "scientific": "Asphalted well",
+      "genus": "Asphalted "
+    },
+    {
+      "common": "Atlas cedar",
+      "scientific": "Cedrus atlantica glauca",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Atlas Cedar",
+      "scientific": "Cedrus atlantica",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Atlas Cedar",
+      "scientific": "Cedrus atlantica",
+      "genus": "Cedrus atlantica"
+    },
+    {
+      "common": "ATLAS CEDAR",
+      "scientific": "Cedrus atlantica",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Austin Griffiths Manzanita",
+      "scientific": "Arctostaphylos manzanita_x_densiflora",
+      "genus": "Arctostaphylos"
+    },
+    {
+      "common": "Australian Flame Tree",
+      "scientific": "Brachychiton acerifolius",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Australian Flame Tree",
+      "scientific": "Brachychiton acerifolius",
+      "genus": "Brachychiton acerifolius"
+    },
+    {
+      "common": "Australian Tea Tree",
+      "scientific": "Leptospermum laevigatum",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Australian Tea Tree",
+      "scientific": "Leptospermum laevigatum",
+      "genus": "Leptospermum laevigatum"
+    },
+    {
+      "common": "AUSTRALIAN TEA TREE",
+      "scientific": "Leptospermum laevigatum",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Australian willow",
+      "scientific": "Australian Willow Geijera parviflora",
+      "genus": "Australian "
+    },
+    {
+      "common": "Australian willow",
+      "scientific": "Geijera parviflora/ australian willow",
+      "genus": "Geijera "
+    },
+    {
+      "common": "Australian willow",
+      "scientific": "Geijera parviflora (Australian willow)",
+      "genus": "Geijera "
+    },
+    {
+      "common": "Australian willow",
+      "scientific": "Tilia tomentosa 'Silver Lining' (silver linden)",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Australian Willow",
+      "scientific": "Geijera parviflora",
+      "genus": "Geijera "
+    },
+    {
+      "common": "Australian Willow",
+      "scientific": "Geijera parviflora",
+      "genus": "Geijera parviflora"
+    },
+    {
+      "common": "AUSTRALIAN WILLOW",
+      "scientific": "Geijera parviflora",
+      "genus": "Geijera "
+    },
+    {
+      "common": "Autumn Blaze Freeman Maple",
+      "scientific": "Acer x freemanii 'Autumn Blaze'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze Freeman Maple",
+      "scientific": "Acer x freemanii 'Autumn Blaze'",
+      "genus": "Acer x freemanii 'Autumn Blaze'"
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer ? freemanii 'Jeffersred'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer freemanii 'Jeffersred'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer freemanii 'Jeffersred' (Autumn Blaze maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer x freemanii",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer x freemanii 'Jeffersred'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer x freemanii 'Jeffersred' (Autumn Blaze)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze maple",
+      "scientific": "Acer x freemanii 'Jeffersred' (Autumn Blaze maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze Red Maple",
+      "scientific": "Acer x freemanii",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze Red Maple",
+      "scientific": "Acer x freemanii 'Jeffersred' (Autumn Blaze red maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Autumn Blaze Red Maple",
+      "scientific": "Acer x freemanii 'Jeffersred' (Autumn Blaze Red Maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "AUTUMN GOLD GINKGO",
+      "scientific": "Ginkgo biloba Autumn Gold",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "AUTUMN PURPLE ASH",
+      "scientific": "Fraxinus americana Autumn Purple",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Autumn Sentinel Ginkgo",
+      "scientific": "Ginkgo biloba 'Autumn Sentinel'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Autumn Sentinel Ginkgo",
+      "scientific": "Ginkgo biloba 'Autumn Sentinel'",
+      "genus": "Ginkgo biloba 'Autumn Sentinel'"
+    },
+    {
+      "common": "Avacado",
+      "scientific": "Persea americana",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Bacon avocado",
+      "genus": "Bacon "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'Bacon' (avocado)",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'hass'",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'Hass'",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana (Hass)",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'Hass' (avocado)",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'Mexicola Grande' (avocado)",
+      "genus": "Persea "
+    },
+    {
+      "common": "avocado",
+      "scientific": "Persea americana 'Stewart' (avocado)",
+      "genus": "Persea "
+    },
+    {
+      "common": "Avocado",
+      "scientific": "Persea americana",
+      "genus": "Persea "
+    },
+    {
+      "common": "Avocado",
+      "scientific": "Persea americana",
+      "genus": "Persea americana"
+    },
+    {
+      "common": "AVOCADO",
+      "scientific": "Persea americana",
+      "genus": "Persea "
+    },
+    {
+      "common": "Avocado Hass",
+      "scientific": "Persea americana",
+      "genus": "Persea "
+    },
+    {
+      "common": "BAILEY ACACIA",
+      "scientific": "Acacia baileyana",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Bailey's Acacia",
+      "scientific": "Acacia baileyana",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Bailey's Acacia",
+      "scientific": "Acacia baileyana",
+      "genus": "Acacia baileyana"
+    },
+    {
+      "common": "Bald Cypres",
+      "scientific": "Taxodium distichum",
+      "genus": "Taxodium"
+    },
+    {
+      "common": "Bald Cypress",
+      "scientific": "Taxodium distichum",
+      "genus": "Taxodium "
+    },
+    {
+      "common": "Bamboo",
+      "scientific": "Bamboo species",
+      "genus": "Bamboo "
+    },
+    {
+      "common": "Bamboo Species",
+      "scientific": "Bambusa spp",
+      "genus": "Bambusa "
+    },
+    {
+      "common": "Bamboo Species",
+      "scientific": "Bambusa spp",
+      "genus": "Bambusa spp"
+    },
+    {
+      "common": "Banana",
+      "scientific": "Musa acuminata",
+      "genus": "Musa "
+    },
+    {
+      "common": "Banana",
+      "scientific": "Musa spp",
+      "genus": "Musa "
+    },
+    {
+      "common": "Banana",
+      "scientific": "Musa spp",
+      "genus": "Musa spp"
+    },
+    {
+      "common": "Banks Grevillea",
+      "scientific": "Grevillea banksii",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Banyan",
+      "scientific": "Ficus species",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Banyan, Chinese",
+      "scientific": "Ficus microcarpa",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Banyan Fig",
+      "scientific": "Ficus retusa nitida",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Banyan Fig",
+      "scientific": "Ficus retusa nitida",
+      "genus": "Ficus retusa nitida"
+    },
+    {
+      "common": "Basswood",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Basswood",
+      "scientific": "Tilia species",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Basswood",
+      "scientific": "Tilia tomentosa 'Sterling Silver'",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Basswood, American",
+      "scientific": "Tilia americana",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Basswood Linden",
+      "scientific": "Tilia americana",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Basswood Linden",
+      "scientific": "Tilia americana",
+      "genus": "Tilia americana"
+    },
+    {
+      "common": "Bayberry, California",
+      "scientific": "Morella californica",
+      "genus": "Morella "
+    },
+    {
+      "common": "Beech",
+      "scientific": "Fagus species",
+      "genus": "Fagus "
+    },
+    {
+      "common": "Beech, European",
+      "scientific": "Fagus sylvatica",
+      "genus": "Fagus "
+    },
+    {
+      "common": "Beefwood: Drooping She-Oak",
+      "scientific": "Casurina stricta",
+      "genus": "Casurina "
+    },
+    {
+      "common": "Beefwood: Drooping She-Oak",
+      "scientific": "Casurina stricta",
+      "genus": "Casurina stricta"
+    },
+    {
+      "common": "BEEFWOOD SPECIES",
+      "scientific": "Casuarina spp.",
+      "genus": "Casuarina "
+    },
+    {
+      "common": "Bigleaf Maple",
+      "scientific": "Acer macrophyllum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Big Leaf Maple",
+      "scientific": "Acer macrophyllum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Big Leaf Maple",
+      "scientific": "Acer macrophyllum",
+      "genus": "Acer macrophyllum"
+    },
+    {
+      "common": "Bing Cherry",
+      "scientific": "Prunus avium 'Bing'",
+      "genus": "Prunus"
+    },
+    {
+      "common": "Birch",
+      "scientific": "Betula species",
+      "genus": "Betula "
+    },
+    {
+      "common": "Birch",
+      "scientific": "Betula spp",
+      "genus": "Betula "
+    },
+    {
+      "common": "Birch",
+      "scientific": "Betula spp",
+      "genus": "Betula spp"
+    },
+    {
+      "common": "Birchbark Cherry",
+      "scientific": "Prunus serrula",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Birchbark Cherry",
+      "scientific": "Prunus serrula",
+      "genus": "Prunus serrula"
+    },
+    {
+      "common": "Birch, European White",
+      "scientific": "Betula pendula",
+      "genus": "Betula "
+    },
+    {
+      "common": "Birch, Paper",
+      "scientific": "Betula papyrifera",
+      "genus": "Betula "
+    },
+    {
+      "common": "Birch, River",
+      "scientific": "Betula nigra",
+      "genus": "Betula "
+    },
+    {
+      "common": "BIRCH SPECIES",
+      "scientific": "Betula spp.",
+      "genus": "Betula "
+    },
+    {
+      "common": "Bishop Pine",
+      "scientific": "Pinus muricata",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Bishop Pine",
+      "scientific": "Pinus muricata",
+      "genus": "Pinus muricata"
+    },
+    {
+      "common": "Bitter Leaf",
+      "scientific": "Vernonia amydalina",
+      "genus": "Vernonia "
+    },
+    {
+      "common": "BLACK ACACIA",
+      "scientific": "Acacia melanoxylon",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Black Birch",
+      "scientific": "Betula nigra 'Heritage'",
+      "genus": "Betula "
+    },
+    {
+      "common": "Black Cottonwood Poplar",
+      "scientific": "Populus trichocarpa",
+      "genus": "Populus "
+    },
+    {
+      "common": "Black Cottonwood Poplar",
+      "scientific": "Populus trichocarpa",
+      "genus": "Populus trichocarpa"
+    },
+    {
+      "common": "Black Locust",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Black Locust",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia pseudoacacia"
+    },
+    {
+      "common": "BLACK LOCUST",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia "
+    },
+    {
+      "common": "black maple",
+      "scientific": "Acer nigrum 'Greencolumn' (black maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "black maple",
+      "scientific": "Acer nigrum 'Greencolumn' (Black Maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Black Mission Fig",
+      "scientific": "Ficus carica 'Black Mission'",
+      "genus": "Ficus carica 'Black Mission'"
+    },
+    {
+      "common": "BLACK POPLAR",
+      "scientific": "Populus nigra",
+      "genus": "Populus "
+    },
+    {
+      "common": "BLACKSTEM PITTOSPORUM",
+      "scientific": "Pittosporum tenuifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Blackwood Acacia",
+      "scientific": "Acacia melanoxylon",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Blackwood Acacia",
+      "scientific": "Acacia melanoxylon",
+      "genus": "Acacia melanoxylon"
+    },
+    {
+      "common": "Bloodgood Japanese Maple",
+      "scientific": "Acer palmatum 'Bloodgood'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Bloodgood Japanese Maple",
+      "scientific": "Acer palmatum 'Bloodgood'",
+      "genus": "Acer palmatum 'Bloodgood'"
+    },
+    {
+      "common": "Bloodgood London Plane",
+      "scientific": "Platanus x hispanica 'Bloodgood'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Bloodgood London Plane",
+      "scientific": "Platanus x hispanica 'Bloodgood'",
+      "genus": "Platanus x hispanica 'Bloodgood'"
+    },
+    {
+      "common": "Blossom, Blue",
+      "scientific": "Ceanothus thyrsiflorus",
+      "genus": "Ceanothus "
+    },
+    {
+      "common": "Blue Atlas Cedar",
+      "scientific": "Cedrus atlantica Glauca",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Blue Atlas Cedar",
+      "scientific": "Cedrus atlantica Glauca",
+      "genus": "Cedrus atlantica Glauca"
+    },
+    {
+      "common": "Blueberry Tree, Japanese",
+      "scientific": "Elaeocarpus decipiens",
+      "genus": "Elaeocarpus "
+    },
+    {
+      "common": "Blueblossom Ceanothus",
+      "scientific": "Ceanothus thyrsiflorus",
+      "genus": "Ceanothus thyrsiflorus"
+    },
+    {
+      "common": "Blue Elderberry",
+      "scientific": "Sambucus mexicana",
+      "genus": "Sambucus "
+    },
+    {
+      "common": "Blue Elderberry",
+      "scientific": "Sambucus mexicana",
+      "genus": "Sambucus mexicana"
+    },
+    {
+      "common": "Blue Gum",
+      "scientific": "Eucalyptus globulus",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Blue Gum",
+      "scientific": "Eucalyptus globulus",
+      "genus": "Eucalyptus globulus"
+    },
+    {
+      "common": "BLUE GUM",
+      "scientific": "Eucalyptus globulus",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Blue hesper palm",
+      "scientific": "Brahea armata",
+      "genus": "Brahea armata"
+    },
+    {
+      "common": "Blue Oak",
+      "scientific": "Quercus douglasii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Blue Oak",
+      "scientific": "Quercus douglasii",
+      "genus": "Quercus douglasii"
+    },
+    {
+      "common": "Blue Potato Bush",
+      "scientific": "Lycianthes rantonnetii",
+      "genus": "Lycianthes "
+    },
+    {
+      "common": "Boldo",
+      "scientific": "Peumus boldo",
+      "genus": "Peumus "
+    },
+    {
+      "common": "Bottlebrush",
+      "scientific": "Callistemon species",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "BOTTLEBRUSH",
+      "scientific": "Callistemon spp.",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Bottlebrush Buckeye",
+      "scientific": "Aesculus parviflora",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Bottlebrush, Red",
+      "scientific": "Callistemon citrinus",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Bottlebrush, Weeping",
+      "scientific": "Callistemon viminalis",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Bottle Tree",
+      "scientific": "Brachychiton populneus",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Bottle Tree",
+      "scientific": "Brachychiton populneus",
+      "genus": "Brachychiton populneus"
+    },
+    {
+      "common": "BOTTLE TREE",
+      "scientific": "Brachychiton populneus",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Bottle Tree, Flame",
+      "scientific": "Brachychiton acerifolius",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Bottle tree, Queensland",
+      "scientific": "Brachychiton rupestris",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Bougainvillea",
+      "scientific": "Bougainvillea spectabilis",
+      "genus": "Bougainvillea "
+    },
+    {
+      "common": "Box, Brisbane",
+      "scientific": "Tristaniopsis conferta",
+      "genus": "Tristaniopsis "
+    },
+    {
+      "common": "Boxelder",
+      "scientific": "Acer negundo",
+      "genus": "Acer "
+    },
+    {
+      "common": "Box Elder",
+      "scientific": "Acer negundo",
+      "genus": "Acer "
+    },
+    {
+      "common": "Box Elder",
+      "scientific": "Acer negundo",
+      "genus": "Acer negundo"
+    },
+    {
+      "common": "Box Elder",
+      "scientific": "Acer negundo 'Sensation' (Sensation boxelder)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Boxwood, Common",
+      "scientific": "Buxus sempervirens",
+      "genus": "Buxus "
+    },
+    {
+      "common": "Brachychiton discolor",
+      "scientific": "Brachychiton discolor",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Brachychiton discolor",
+      "scientific": "Brachychiton discolor",
+      "genus": "Brachychiton discolor"
+    },
+    {
+      "common": "BRADFORD PEAR",
+      "scientific": "Pyrus calleryana Bradford",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "BRANDYWINE MAPLE",
+      "scientific": "Acer rubrum Brandywine",
+      "genus": "Acer "
+    },
+    {
+      "common": "Brazilian Pepper",
+      "scientific": "Schinus terebinthifolius",
+      "genus": "Schinus "
+    },
+    {
+      "common": "Brazilian Pepper",
+      "scientific": "Schinus terebinthifolius",
+      "genus": "Schinus terebinthifolius"
+    },
+    {
+      "common": "BRAZILIAN PEPPER",
+      "scientific": "Schinus terebinthifolius",
+      "genus": "Schinus "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus (Brisbane box)",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus (Tristania conferta)",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus (Tristania conferta) (Brisbane box)",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus / Tristania conferta (Brisbane box)",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane box",
+      "scientific": "Lophostemon confertus (Tristania conferta/ Brisbane Box)",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane Box",
+      "scientific": "Lophostemon confertus",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Brisbane Box",
+      "scientific": "Lophostemon confertus",
+      "genus": "Lophostemon confertus"
+    },
+    {
+      "common": "BRISBANE BOX",
+      "scientific": "Lophostemon confertus",
+      "genus": "Lophostemon "
+    },
+    {
+      "common": "Bronze Loquat",
+      "scientific": "Eriobotrya deflexa",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Bronze Loquat",
+      "scientific": "Eriobotrya deflexa",
+      "genus": "Eriobotrya deflexa"
+    },
+    {
+      "common": "BRONZE LOQUAT",
+      "scientific": "Eriobotrya deflexa",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Brown Turkey Fig",
+      "scientific": "Ficus carica 'Brown Turkey'",
+      "genus": "Ficus carica 'Brown Turkey'"
+    },
+    {
+      "common": "Brush Box",
+      "scientific": "Lophostemon confertus",
+      "genus": "Lophostemon"
+    },
+    {
+      "common": "Brush Box",
+      "scientific": "Tristania conferta",
+      "genus": "Lophostemon"
+    },
+    {
+      "common": "Brush Cherry",
+      "scientific": "Syzygium paniculatum",
+      "genus": "Syzygium "
+    },
+    {
+      "common": "Brush Cherry",
+      "scientific": "Syzygium paniculatum",
+      "genus": "Syzygium paniculatum"
+    },
+    {
+      "common": "BRUSH CHERRY",
+      "scientific": "Syzygium paniculatum",
+      "genus": "Syzygium "
+    },
+    {
+      "common": "Brush holly",
+      "scientific": "Xylosma congestum",
+      "genus": "Xylosma "
+    },
+    {
+      "common": "Buckeye, California",
+      "scientific": "Aesculus californica",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Buckeye, Red",
+      "scientific": "Aesculus pavia",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Buckthorn, Carolina",
+      "scientific": "Rhamnus caroliniana",
+      "genus": "Rhamnus "
+    },
+    {
+      "common": "Buckthorn, European",
+      "scientific": "Rhamnus cathartica",
+      "genus": "Rhamnus "
+    },
+    {
+      "common": "Bunya Bunya",
+      "scientific": "Araucaria bidwillii",
+      "genus": "Araucaria bidwillii"
+    },
+    {
+      "common": "Bunya, Bunya",
+      "scientific": "Araucaria bidwillii",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Burgundy Sweet Gum",
+      "scientific": "Liquidambar styraciflua 'Burgundy'",
+      "genus": "Liquidambar styraciflua 'Burgundy'"
+    },
+    {
+      "common": "bur oak",
+      "scientific": "Urban Pinnacle Oak Quercus macrocarpa",
+      "genus": "Urban "
+    },
+    {
+      "common": "BUR OAK",
+      "scientific": "Quercus macrocarpa",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Bushy Yate",
+      "scientific": "Eucalyptus lehmanni",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Bushy Yate",
+      "scientific": "Eucalyptus lehmanni",
+      "genus": "Eucalyptus lehmanni"
+    },
+    {
+      "common": "BUSHY YATE",
+      "scientific": "Eucalyptus lehmannii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Butterfly Bush",
+      "scientific": "Buddleja davidii",
+      "genus": "Buddleja "
+    },
+    {
+      "common": "Butternut",
+      "scientific": "Juglans cinerea",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Buttonwood",
+      "scientific": "Conocarpus erectus",
+      "genus": "Conocarpus "
+    },
+    {
+      "common": "Cabada palm",
+      "scientific": "Dypsis cabadae",
+      "genus": "Dypsis "
+    },
+    {
+      "common": "Cabada palm",
+      "scientific": "Dypsis cabadae",
+      "genus": "Dypsis cabadae"
+    },
+    {
+      "common": "Cabbage tree",
+      "scientific": "Cussonia spicata",
+      "genus": "Cussonia "
+    },
+    {
+      "common": "Cabbage tree",
+      "scientific": "Cussonia spicata",
+      "genus": "Cussonia spicata"
+    },
+    {
+      "common": "Cajeput",
+      "scientific": "Melaleuca quinquenervia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Cajeput",
+      "scientific": "Melaleuca quinquenervia",
+      "genus": "Melaleuca quinquenervia"
+    },
+    {
+      "common": "cajeput tree",
+      "scientific": "Melaleuca quinquenervia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Cajeput Tree",
+      "scientific": "Melaleuca linariifolia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "CAJEPUT TREE",
+      "scientific": "Melaleuca quinquenervia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "California bay",
+      "scientific": "Umbellularia californica",
+      "genus": "Umbellularia "
+    },
+    {
+      "common": "California Bay",
+      "scientific": "Umbellularia californica",
+      "genus": "Umbellularia "
+    },
+    {
+      "common": "California Bay",
+      "scientific": "Umbellularia californica",
+      "genus": "Umbellularia californica"
+    },
+    {
+      "common": "CALIFORNIA BAY",
+      "scientific": "Umbellularia californica",
+      "genus": "Umbellularia "
+    },
+    {
+      "common": "California Black Oak",
+      "scientific": "Quercus keloggii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "California Buckeye",
+      "scientific": "Aesculus californica",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "California Buckeye",
+      "scientific": "Aesculus californica",
+      "genus": "Aesculus californica"
+    },
+    {
+      "common": "CALIFORNIA BUCKEYE",
+      "scientific": "Aesculus californica",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "California Fan Palm",
+      "scientific": "Washingtonia filifera",
+      "genus": "Washingtonia "
+    },
+    {
+      "common": "California Fan Palm",
+      "scientific": "Washingtonia filifera",
+      "genus": "Washingtonia filifera"
+    },
+    {
+      "common": "California juniper",
+      "scientific": "Juniperus californica",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "California juniper",
+      "scientific": "Juniperus californica",
+      "genus": "Juniperus californica"
+    },
+    {
+      "common": "California lilac",
+      "scientific": "Ceanothus Sps",
+      "genus": "Ceanothus "
+    },
+    {
+      "common": "California lilac",
+      "scientific": "Ceanothus Sps",
+      "genus": "Ceanothus Sps"
+    },
+    {
+      "common": "California Lilac",
+      "scientific": "Ceanothus 'Ray Hartman'",
+      "genus": "Ceanothus "
+    },
+    {
+      "common": "California Lilac 'Ray Hartman'",
+      "scientific": "Ceanothus 'Ray Hartman'",
+      "genus": "Ceanothus "
+    },
+    {
+      "common": "California Lilac 'Ray Hartman'",
+      "scientific": "Ceanothus 'Ray Hartman'",
+      "genus": "Ceanothus 'Ray Hartman'"
+    },
+    {
+      "common": "California nutmeg",
+      "scientific": "Torreya californica",
+      "genus": "Torreya californica"
+    },
+    {
+      "common": "California Pepper",
+      "scientific": "Schinus molle",
+      "genus": "Schinus "
+    },
+    {
+      "common": "California Pepper",
+      "scientific": "Schinus molle",
+      "genus": "Schinus molle"
+    },
+    {
+      "common": "CALIFORNIA PEPPER",
+      "scientific": "Schinus molle",
+      "genus": "Schinus "
+    },
+    {
+      "common": "California privet",
+      "scientific": "Ligustrum ovalifolium",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "California privet",
+      "scientific": "Ligustrum ovalifolium",
+      "genus": "Ligustrum ovalifolium"
+    },
+    {
+      "common": "California sycamore",
+      "scientific": "Platanus racemosa",
+      "genus": "Platanus"
+    },
+    {
+      "common": "California Sycamore",
+      "scientific": "Platanus racemosa",
+      "genus": "Platanus "
+    },
+    {
+      "common": "California Sycamore",
+      "scientific": "Platanus racemosa",
+      "genus": "Platanus racemosa"
+    },
+    {
+      "common": "CALIFORNIA SYCAMORE",
+      "scientific": "Platanus racemosa",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Camden Wollybutt",
+      "scientific": "Eucalyptus macarthuri",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Camden Wollybutt",
+      "scientific": "Eucalyptus macarthuri",
+      "genus": "Eucalyptus macarthuri"
+    },
+    {
+      "common": "Camellia",
+      "scientific": "Camellia japonica",
+      "genus": "Camellia "
+    },
+    {
+      "common": "CAMELLIA",
+      "scientific": "Camellia recurvata",
+      "genus": "Camellia "
+    },
+    {
+      "common": "Camphor Tree",
+      "scientific": "Cinnamomum camphora",
+      "genus": "Cinnamomum "
+    },
+    {
+      "common": "Camphor Tree",
+      "scientific": "Cinnamomum camphora",
+      "genus": "Cinnamomum camphora"
+    },
+    {
+      "common": "CAMPHOR TREE",
+      "scientific": "Cinnamomum camphora",
+      "genus": "Cinnamomum "
+    },
+    {
+      "common": "Canadian Poplar",
+      "scientific": "Populus canadensis",
+      "genus": "Populus "
+    },
+    {
+      "common": "Canadian Poplar",
+      "scientific": "Populus canadensis",
+      "genus": "Populus canadensis"
+    },
+    {
+      "common": "Canary Island Date Palm",
+      "scientific": "Phoenix canariensis",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Canary Island Date Palm",
+      "scientific": "Phoenix canariensis",
+      "genus": "Phoenix canariensis"
+    },
+    {
+      "common": "CANARY ISLAND DATE PALM",
+      "scientific": "Phoenix canariensis",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Canary Island pine",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus"
+    },
+    {
+      "common": "Canary Island Pine",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus"
+    },
+    {
+      "common": "Canary Island Pine",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Canary Island Pine",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus canariensis"
+    },
+    {
+      "common": "CANARY ISLAND PINE",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Candelabra tree",
+      "scientific": "Euphorbia ingens",
+      "genus": "Euphorbia ingens"
+    },
+    {
+      "common": "Carob",
+      "scientific": "Ceratonia siliqua",
+      "genus": "Ceratonia "
+    },
+    {
+      "common": "Carob",
+      "scientific": "Ceratonia siliqua",
+      "genus": "Ceratonia siliqua"
+    },
+    {
+      "common": "CAROB",
+      "scientific": "Ceratonia siliqua",
+      "genus": "Ceratonia "
+    },
+    {
+      "common": "Carolina Cherry Laurel",
+      "scientific": "Prunus caroliniana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Carolina Cherry Laurel",
+      "scientific": "Prunus caroliniana",
+      "genus": "Prunus caroliniana"
+    },
+    {
+      "common": "CAROLINA LAUREL CHERRY",
+      "scientific": "Prunus caroliniana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Carrotwood",
+      "scientific": "Cupaniopsis anacardioides",
+      "genus": "Cupaniopsis "
+    },
+    {
+      "common": "Carrotwood",
+      "scientific": "Cupaniopsis anacardioides",
+      "genus": "Cupaniopsis anacardioides"
+    },
+    {
+      "common": "CARROTWOOD",
+      "scientific": "Cupaniopsis anacardioides",
+      "genus": "Cupaniopsis "
+    },
+    {
+      "common": "Castor Bean",
+      "scientific": "Ricinus communis",
+      "genus": "Ricinus "
+    },
+    {
+      "common": "Catalina Cherry",
+      "scientific": "Prunus lyonii",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Catalina Cherry",
+      "scientific": "Prunus lyonii",
+      "genus": "Prunus lyonii"
+    },
+    {
+      "common": "CATALINA CHERRY",
+      "scientific": "Prunus ilicifolia ssp lyonii",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Catalina ironwood",
+      "scientific": "Catalina ironwood (Lyonothamnus floribundus)",
+      "genus": "Catalina "
+    },
+    {
+      "common": "Catalina ironwood",
+      "scientific": "Lyonothamnus floribundus",
+      "genus": "Lyonothamnus "
+    },
+    {
+      "common": "Catalina ironwood",
+      "scientific": "Lyonothamnus floribundus asplenifolius",
+      "genus": "Lyonothamnus "
+    },
+    {
+      "common": "Catalina ironwood",
+      "scientific": "Lyonothamnus floribundus asplenifolius (Catalina ironwood)",
+      "genus": "Lyonothamnus "
+    },
+    {
+      "common": "Catalina Ironwood",
+      "scientific": "Lyonothamnus Floribundus",
+      "genus": "Lyonothamnus"
+    },
+    {
+      "common": "Catalpa",
+      "scientific": "Catalpa species",
+      "genus": "Catalpa "
+    },
+    {
+      "common": "CATALPA",
+      "scientific": "Catalpa spp.",
+      "genus": "Catalpa "
+    },
+    {
+      "common": "Catalpa, Southern",
+      "scientific": "Catalpa bignonioides",
+      "genus": "Catalpa "
+    },
+    {
+      "common": "Ceathonus species",
+      "scientific": "Ceanothus",
+      "genus": ""
+    },
+    {
+      "common": "Cedar",
+      "scientific": "Chamaecyparis species",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "Cedar, Alaska",
+      "scientific": "Chamaecyparis nootkatensis",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "Cedar, Atlantic White",
+      "scientific": "Chamaecyparis thyoides",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "Cedar, Atlas",
+      "scientific": "Cedrus atlantica",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "CEDAR BLUE ATLAS",
+      "scientific": "Cedrus atlantica Glauca",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Cedar, Deodar",
+      "scientific": "Cedrus deodara",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Cedar, Incense",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus "
+    },
+    {
+      "common": "Cedar, Japanese Red",
+      "scientific": "Cryptomeria japonica",
+      "genus": "Cryptomeria "
+    },
+    {
+      "common": "Cedar, Northern White",
+      "scientific": "Thuja occidentalis",
+      "genus": "Thuja "
+    },
+    {
+      "common": "Cedar, Port Orford",
+      "scientific": "Chamaecyparis lawsoniana",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "Cedar, Red",
+      "scientific": "Thuja species",
+      "genus": "Thuja "
+    },
+    {
+      "common": "Cedar, Western Red",
+      "scientific": "Thuja plicata",
+      "genus": "Thuja "
+    },
+    {
+      "common": "Chamaecyparis species",
+      "scientific": "Chamaecyparis species",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "Chamaecyparis species",
+      "scientific": "Chamaecyparis species",
+      "genus": "Chamaecyparis species"
+    },
+    {
+      "common": "Champa",
+      "scientific": "Magnolia champaca",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Champa",
+      "scientific": "Magnolia champaca",
+      "genus": "Magnolia champaca"
+    },
+    {
+      "common": "Champak",
+      "scientific": "Michelia champaca",
+      "genus": "Michelia "
+    },
+    {
+      "common": "CHANTICLEER PEAR",
+      "scientific": "Pyrus calleryana Chanticleer",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Chaste Tree",
+      "scientific": "Vitex agnus-castus",
+      "genus": "Vitex "
+    },
+    {
+      "common": "Cheesewood, Cape",
+      "scientific": "Pittosporum viridiflorum",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Cheesewood, Stiffleaf",
+      "scientific": "Pittosporum crassifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Cherimoya",
+      "scientific": "Annona cherimola",
+      "genus": "Annona "
+    },
+    {
+      "common": "Cherry",
+      "scientific": "Prunus spp",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry",
+      "scientific": "Prunus spp",
+      "genus": "Prunus spp"
+    },
+    {
+      "common": "Cherry, Black",
+      "scientific": "Prunus serotina",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Catalina",
+      "scientific": "Prunus ilicifolia ssp. lyonii",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Higan",
+      "scientific": "Prunus subhirtella",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Hollyleaf",
+      "scientific": "Prunus ilicifolia",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Kwanzan",
+      "scientific": "Prunus shrubs",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry Plum",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry Plum",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus cerasifera"
+    },
+    {
+      "common": "Cherry Plum",
+      "scientific": "Prunus cerasifera Krauter Vesuvius",
+      "genus": "Prunus"
+    },
+    {
+      "common": "Cherry Plum",
+      "scientific": "Prunus spp 'Purpurea'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry Plum",
+      "scientific": "Prunus spp 'Purpurea'",
+      "genus": "Prunus spp 'Purpurea'"
+    },
+    {
+      "common": "Cherry, Shirofugen",
+      "scientific": "Prunus serrulata 'Shirofugen'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Shirotae",
+      "scientific": "Prunus serrulata 'Shirotae'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Sweet",
+      "scientific": "Prunus avium",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Cherry, Yoshino",
+      "scientific": "Prunus x yedoensis",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Chery, Japanese Flowering",
+      "scientific": "Prunus serrulata",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Chilean pepper tree",
+      "scientific": "Schinus polygamus",
+      "genus": "Schinus polygamus"
+    },
+    {
+      "common": "Chilean Soapbark",
+      "scientific": "Quillaja saponaria",
+      "genus": "Quillaja "
+    },
+    {
+      "common": "Chilean Soapbark",
+      "scientific": "Quillaja saponaria",
+      "genus": "Quillaja saponaria"
+    },
+    {
+      "common": "Chilean Wine Palm",
+      "scientific": "Jubaea chilensis",
+      "genus": "Jubaea "
+    },
+    {
+      "common": "Chilean Wine Palm",
+      "scientific": "Jubaea chilensis",
+      "genus": "Jubaea chilensis"
+    },
+    {
+      "common": "Chinaberry",
+      "scientific": "Melia azerdarach",
+      "genus": "Melia "
+    },
+    {
+      "common": "Chinaberry",
+      "scientific": "Melia azerdarach",
+      "genus": "Melia azerdarach"
+    },
+    {
+      "common": "China Doll Tree",
+      "scientific": "Radermachera sinica",
+      "genus": "Radermachera "
+    },
+    {
+      "common": "China Doll Tree",
+      "scientific": "Radermachera sinica",
+      "genus": "Radermachera sinica"
+    },
+    {
+      "common": "Chinese Banyan",
+      "scientific": "Ficus microcarpa",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Chinese Banyan",
+      "scientific": "Ficus microcarpa",
+      "genus": "Ficus microcarpa"
+    },
+    {
+      "common": "Chinese Elm",
+      "scientific": "Ulmus parvifolia",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Chinese Elm",
+      "scientific": "Ulmus parvifolia",
+      "genus": "Ulmus parvifolia"
+    },
+    {
+      "common": "CHINESE ELM",
+      "scientific": "Ulmus parvifolia",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Chinese Elm 'Athena'",
+      "scientific": "Ulmus parvifolia 'Athena'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Chinese Elm 'Athena'",
+      "scientific": "Ulmus parvifolia 'Athena'",
+      "genus": "Ulmus parvifolia 'Athena'"
+    },
+    {
+      "common": "Chinese fan palm",
+      "scientific": "Livistona chinensis",
+      "genus": "Livistona chinensis"
+    },
+    {
+      "common": "Chinese flame tree",
+      "scientific": "Koelreuteria bipinnata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Chinese flame tree",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Chinese Flame Tree",
+      "scientific": "Koelreuteria bipinnata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Chinese Flame Tree",
+      "scientific": "Koelreuteria bipinnata",
+      "genus": "Koelreuteria bipinnata"
+    },
+    {
+      "common": "CHINESE FLAME TREE",
+      "scientific": "Koelreuteria bipinnata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Chinese Fringe Flower",
+      "scientific": "Loropetalum chinense",
+      "genus": "Loropetalum "
+    },
+    {
+      "common": "Chinese Fringe Tree",
+      "scientific": "Chionanthus retusa",
+      "genus": "Chionanthus "
+    },
+    {
+      "common": "Chinese Fringe Tree",
+      "scientific": "Chionanthus retusa",
+      "genus": "Chionanthus retusa"
+    },
+    {
+      "common": "CHINESE FRINGE TREE",
+      "scientific": "Chionanthus retusus",
+      "genus": "Chionanthus "
+    },
+    {
+      "common": "Chinese Hackberry",
+      "scientific": "Celtis sinensis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Chinese Hackberry",
+      "scientific": "Celtis sinensis",
+      "genus": "Celtis sinensis"
+    },
+    {
+      "common": "CHINESE HACKBERRY",
+      "scientific": "Celtis sinensis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Chinese Jujube",
+      "scientific": "Ziziphus jujuba",
+      "genus": "Ziziphus "
+    },
+    {
+      "common": "Chinese Magnolia",
+      "scientific": "Magnolia x soulangiana 'Rustica Rubra'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Chinese pistache",
+      "scientific": "Chinese pistache (Pistacia chinensis)",
+      "genus": "Chinese "
+    },
+    {
+      "common": "Chinese pistache",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Chinese pistache",
+      "scientific": "Pistacia chinensis 'Keith Davey'",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Chinese Pistache",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia"
+    },
+    {
+      "common": "Chinese Pistache",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Chinese Pistache",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia chinensis"
+    },
+    {
+      "common": "Chinese Pistache",
+      "scientific": "Pistacia chinensis (Chinese pistache)",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "CHINESE PISTACHE",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Chinese scholar tree",
+      "scientific": "Styphnolobium japonicum",
+      "genus": "Styphnolobium "
+    },
+    {
+      "common": "Chinese scholar tree",
+      "scientific": "Styphnolobium japonicum",
+      "genus": "Styphnolobium japonicum"
+    },
+    {
+      "common": "Chinese Sweet Gum",
+      "scientific": "Liquidambar formosana",
+      "genus": "Liquidambar formosana"
+    },
+    {
+      "common": "Chinese Tallow",
+      "scientific": "Sapium sebiferum",
+      "genus": "Sapium sebiferum"
+    },
+    {
+      "common": "CHINESE TALLOW TREE",
+      "scientific": "Triadica sebifera",
+      "genus": "Triadica "
+    },
+    {
+      "common": "Chionanthus retusus (Chinese fringe tree)",
+      "scientific": "Chionanthus retusus (Chinese Fringe Tree)",
+      "genus": "Chionanthus "
+    },
+    {
+      "common": "chitalpa",
+      "scientific": "Chitalpa tashkentensis 'Morning Cloud'",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "chitalpa",
+      "scientific": "Chitalpa tashkentensis 'Pink Dawn'",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "chitalpa",
+      "scientific": "Chitalpa x tashkentensis 'Pink Dawn'",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "chitalpa",
+      "scientific": "X Chitalpa tashkentensis 'Pink Dawn'",
+      "genus": "X "
+    },
+    {
+      "common": "Chitalpa",
+      "scientific": "Chitalpa species",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "Chitalpa",
+      "scientific": "Chitalpa tashkentensis 'Morning Cloud'",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "Chitalpa tashkentensis",
+      "scientific": "Chitalpa tashkentensis",
+      "genus": "Chitalpa "
+    },
+    {
+      "common": "Chitalpa tashkentensis",
+      "scientific": "Chitalpa tashkentensis",
+      "genus": "Chitalpa tashkentensis"
+    },
+    {
+      "common": "Chokeberry",
+      "scientific": "Photinia species",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Chokeberry, Red",
+      "scientific": "Aronia arbutifolia",
+      "genus": "Aronia "
+    },
+    {
+      "common": "Christmasberry",
+      "scientific": "Heteromeles arbutifolia",
+      "genus": "Heteromeles "
+    },
+    {
+      "common": "Christmas Berry",
+      "scientific": "Schinus terebinthifolius",
+      "genus": "Schinus "
+    },
+    {
+      "common": "Christmas Tree, New Zealand",
+      "scientific": "Metrosideros excelsus",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "Cider Gum",
+      "scientific": "Eucalyptus gunnii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Cider Gum",
+      "scientific": "Eucalyptus gunnii",
+      "genus": "Eucalyptus gunnii"
+    },
+    {
+      "common": "Cinnamomum species",
+      "scientific": "Cinnamomum",
+      "genus": ""
+    },
+    {
+      "common": "Citrus",
+      "scientific": "Citrus species",
+      "genus": "Citrus "
+    },
+    {
+      "common": "CITRUS",
+      "scientific": "Citrus spp.",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Cliff date palm",
+      "scientific": "Phoenix rupicola",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Coastal Redwood",
+      "scientific": "Sequoia sempervirens",
+      "genus": "Sequoia"
+    },
+    {
+      "common": "Coastal Redwood",
+      "scientific": "Sequoia Sempervirens",
+      "genus": "Sequoia"
+    },
+    {
+      "common": "Coastal Redwood",
+      "scientific": "Sequoia sempervirens 'Aptos Blue'",
+      "genus": "Sequoia "
+    },
+    {
+      "common": "Coastal Redwood",
+      "scientific": "Sequoia Ssempervirens",
+      "genus": "Sequoia"
+    },
+    {
+      "common": "Coast Banksia",
+      "scientific": "Banksia integrifolia",
+      "genus": "Banksia "
+    },
+    {
+      "common": "Coast Banksia",
+      "scientific": "Banksia integrifolia",
+      "genus": "Banksia integrifolia"
+    },
+    {
+      "common": "coast live oak",
+      "scientific": "coast live oak (Quercus agrifolia)",
+      "genus": "coast "
+    },
+    {
+      "common": "coast live oak",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus "
+    },
+    {
+      "common": "coast live oak",
+      "scientific": "Quercus agrifolia (coast live oak)",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Coast Live Oak",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Coast Live Oak",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus agrifolia"
+    },
+    {
+      "common": "Coast Live Oak",
+      "scientific": "Quercus agrifolia (coast live oak)",
+      "genus": "Quercus"
+    },
+    {
+      "common": "COAST LIVE OAK",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Coast Redwood",
+      "scientific": "Sequioa sempervirens",
+      "genus": "Sequoia"
+    },
+    {
+      "common": "Coast Redwood",
+      "scientific": "Sequoia sempervirens",
+      "genus": "Sequoia "
+    },
+    {
+      "common": "Coast Redwood",
+      "scientific": "Sequoia sempervirens",
+      "genus": "Sequoia sempervirens"
+    },
+    {
+      "common": "COAST REDWOOD",
+      "scientific": "Sequoia sempervirens",
+      "genus": "Sequoia "
+    },
+    {
+      "common": "COCKSPUR CORAL TREE",
+      "scientific": "Erythrina crista-galli",
+      "genus": "Erythrina "
+    },
+    {
+      "common": "Coffeeberry Tree",
+      "scientific": "Rhamnus californica",
+      "genus": "Rhamnus "
+    },
+    {
+      "common": "Coffeetree, Kentucky",
+      "scientific": "Gymnocladus dioicus",
+      "genus": "Gymnocladus "
+    },
+    {
+      "common": "Colonial Spirit American elm",
+      "scientific": "Ulmus americana 'Colonial Spirit' (1)/ Lyono. flor. aspl. (7)",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "COLORADO BLUE SPRUCE",
+      "scientific": "Picea pungens",
+      "genus": "Picea "
+    },
+    {
+      "common": "Columbia Hybrid Plane Tree",
+      "scientific": "Platanus x hispanica 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Columbia Hybrid Plane Tree",
+      "scientific": "Platanus x hispanica 'Columbia'",
+      "genus": "Platanus x hispanica 'Columbia'"
+    },
+    {
+      "common": "COLUMBIA PLANE",
+      "scientific": "Platanus X hispanica Columbia",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Columbia Plane Tree",
+      "scientific": "Platanus acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Common Hackberry",
+      "scientific": "Celtis occidentalis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Common Hackberry",
+      "scientific": "Celtis occidentalis",
+      "genus": "Celtis occidentalis"
+    },
+    {
+      "common": "Cook Pine",
+      "scientific": "Araucaria columnaris",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "COPPER BEECH",
+      "scientific": "Fagus sylvatica Purpurea",
+      "genus": "Fagus "
+    },
+    {
+      "common": "Coppertone Loquat",
+      "scientific": "Eriobotrya deflexa 'Coppertone'",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Coppertone Loquat",
+      "scientific": "Eriobotrya deflexa 'Coppertone'",
+      "genus": "Eriobotrya deflexa 'Coppertone'"
+    },
+    {
+      "common": "Coral Bark Maple",
+      "scientific": "Acer palmatum 'Sango Kaku'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Coral Gum",
+      "scientific": "Eucalyptus torquata",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Coral Gum",
+      "scientific": "Eucalyptus torquata",
+      "genus": "Eucalyptus torquata"
+    },
+    {
+      "common": "Coral reef araucaria",
+      "scientific": "Araucaria columnaris",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Coral reef araucaria",
+      "scientific": "Araucaria columnaris",
+      "genus": "Araucaria columnaris"
+    },
+    {
+      "common": "Coral tree",
+      "scientific": "Erythrina caffra",
+      "genus": "Erythrina caffra"
+    },
+    {
+      "common": "Coral Tree",
+      "scientific": "Erythrina crista-galli",
+      "genus": "Erythrina "
+    },
+    {
+      "common": "CORAL TREE",
+      "scientific": "Erythrina spp.",
+      "genus": "Erythrina "
+    },
+    {
+      "common": "Coral Tree, Kaffirboom",
+      "scientific": "Erythrina caffra",
+      "genus": "Erythrina "
+    },
+    {
+      "common": "cork oak",
+      "scientific": "Quercus suber",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Cork Oak",
+      "scientific": "Quercus suber",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Cork Oak",
+      "scientific": "Quercus suber",
+      "genus": "Quercus suber"
+    },
+    {
+      "common": "CORK OAK",
+      "scientific": "Quercus suber",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Corkscrew Willow",
+      "scientific": "Salix matsudana 'Tortuosa'",
+      "genus": "Salix "
+    },
+    {
+      "common": "Corkscrew Willow",
+      "scientific": "Salix matsudana 'Tortuosa'",
+      "genus": "Salix matsudana 'Tortuosa'"
+    },
+    {
+      "common": "CORKSCREW WILLOW",
+      "scientific": "Salix matsudana Tortuosa",
+      "genus": "Salix "
+    },
+    {
+      "common": "Corymbia calophylla",
+      "scientific": "Corymbia calophylla",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "Corymbia calophylla",
+      "scientific": "Corymbia calophylla",
+      "genus": "Corymbia calophylla"
+    },
+    {
+      "common": "Cotoneaster",
+      "scientific": "Cotoneaster buxifolius",
+      "genus": "Cotoneaster "
+    },
+    {
+      "common": "Cotoneaster",
+      "scientific": "Cotoneaster SPP",
+      "genus": "Cotoneaster "
+    },
+    {
+      "common": "Cotoneaster",
+      "scientific": "Cotoneaster SPP",
+      "genus": "Cotoneaster SPP"
+    },
+    {
+      "common": "Cottonwood",
+      "scientific": "Populus species",
+      "genus": "Populus "
+    },
+    {
+      "common": "Cottonwood, Eastern",
+      "scientific": "Populus deltoides",
+      "genus": "Populus "
+    },
+    {
+      "common": "Cottonwood, Fremont",
+      "scientific": "Populus fremontii",
+      "genus": "Populus "
+    },
+    {
+      "common": "Coulter pine",
+      "scientific": "Pinus coulteri",
+      "genus": "Pinus coulteri"
+    },
+    {
+      "common": "Coyote Bush",
+      "scientific": "Baccharis pilularis",
+      "genus": "Baccharis "
+    },
+    {
+      "common": "Crab Apple",
+      "scientific": "Malus",
+      "genus": ""
+    },
+    {
+      "common": "Crab Apple",
+      "scientific": "Malus",
+      "genus": "Malus"
+    },
+    {
+      "common": "CRABAPPLE",
+      "scientific": "Malus floribunda",
+      "genus": "Malus "
+    },
+    {
+      "common": "Crabapple, Common",
+      "scientific": "Malus sylvestris",
+      "genus": "Malus "
+    },
+    {
+      "common": "Crabapple, Japanese Flowering",
+      "scientific": "Malus floribunda",
+      "genus": "Malus "
+    },
+    {
+      "common": "Crape Myrtl",
+      "scientific": "Lagerstroemia Indica x L Fouriei Tuscarora ",
+      "genus": "lagerstroemia"
+    },
+    {
+      "common": "Crape Myrtle",
+      "scientific": "\b",
+      "genus": "Lagerstroemia"
+    },
+    {
+      "common": "Crape Myrtle",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia"
+    },
+    {
+      "common": "Crape Myrtle",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape Myrtle",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia indica"
+    },
+    {
+      "common": "Crape Myrtle",
+      "scientific": "Lagerstromia Indica",
+      "genus": "Lagerstroemia"
+    },
+    {
+      "common": "CRAPE MYRTLE",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crapemyrtle, Common",
+      "scientific": "Lagerstroemia species",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape Myrtle Dark Pink",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crapemyrtle, Giant",
+      "scientific": "Lagerstroemia speciosa",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape Myrtle 'indica x L. fauriei Muskogee'",
+      "scientific": "Lagerstroemia indica x L. fauriei 'Muskogee'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape Myrtle 'Muskogee'",
+      "scientific": "Lagerstroemia x 'Muskogee'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape myrtle species",
+      "scientific": "Lagerstroemia spp",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crapemyrtle 'Tuscarora'",
+      "scientific": "Lagerstroemia x 'Tuscarora'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crape Myrtle 'Tuscarora'",
+      "scientific": "Lagerstroemia x 'Tuscarora'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crepemyrtle",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crepemyrtle",
+      "scientific": "Lagerstroemia x 'Dynamite'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crepemyrtle",
+      "scientific": "Lagerstroemia x 'Muskogee'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Crossberry",
+      "scientific": "Grewia occidentalis",
+      "genus": "Grewia "
+    },
+    {
+      "common": "Crown of Gold Tree",
+      "scientific": "Cassia excelsa",
+      "genus": "Cassia excelsa"
+    },
+    {
+      "common": "Cuban-laurel",
+      "scientific": "Ficus retusa",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Cucumber Tree",
+      "scientific": "Magnolia acuminata",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Currant, Red Flowering",
+      "scientific": "Ribes sanguineum",
+      "genus": "Ribes "
+    },
+    {
+      "common": "Cyclops wattle",
+      "scientific": "Acacia cyclops",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Cyclops wattle",
+      "scientific": "Acacia cyclops",
+      "genus": "Acacia cyclops"
+    },
+    {
+      "common": "Cypress, Arizona",
+      "scientific": "Cupressus arizonica",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Cypress, Bald",
+      "scientific": "Taxodium distichum",
+      "genus": "Taxodium "
+    },
+    {
+      "common": "Cypress, Italian",
+      "scientific": "Cupressus sempervirens",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Cypress, Leyland",
+      "scientific": "Cupressus x leylandii",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Cypress, Monterey",
+      "scientific": "Cupressus macrocarpa",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Cypress species",
+      "scientific": "Cupressus spp",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Cypress species",
+      "scientific": "Cupressus spp",
+      "genus": "Cupressus spp"
+    },
+    {
+      "common": "Dahoon",
+      "scientific": "Ilex cassine",
+      "genus": "Ilex "
+    },
+    {
+      "common": "Dancy Tangerine",
+      "scientific": "Citrus reticulata",
+      "genus": "Citrus"
+    },
+    {
+      "common": "Date Palm",
+      "scientific": "Phoenix dactylifera",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Date Palm",
+      "scientific": "Phoenix dactylifera",
+      "genus": "Phoenix dactylifera"
+    },
+    {
+      "common": "DATE PALM",
+      "scientific": "Phoenix dactylifera",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Date palm (species unknown)",
+      "scientific": "Phoenix spp",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Date palm (species unknown)",
+      "scientific": "Phoenix spp",
+      "genus": "Phoenix spp"
+    },
+    {
+      "common": "Datura",
+      "scientific": "Brugmansia suaveolens",
+      "genus": "Brugmansia "
+    },
+    {
+      "common": "Dawn Redwood",
+      "scientific": "Metasequoia glyplostroboides",
+      "genus": "Metasequoia "
+    },
+    {
+      "common": "Dawn Redwood",
+      "scientific": "Metasequoia glyplostroboides",
+      "genus": "Metasequoia glyplostroboides"
+    },
+    {
+      "common": "DAWN REDWOOD",
+      "scientific": "Metasequoia glyptostroboides",
+      "genus": "Metasequoia "
+    },
+    {
+      "common": "Daybreak Yoshino Cherry",
+      "scientific": "Prunus x yedoensis 'Akebono'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Daybreak Yoshino Cherry",
+      "scientific": "Prunus x yedoensis 'Akebono'",
+      "genus": "Prunus x yedoensis 'Akebono'"
+    },
+    {
+      "common": "D.D. Blanchard Southern Magnolia",
+      "scientific": "Magnolia grandiflora 'D.D. Blanchard'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "D.D. Blanchard Southern Magnolia",
+      "scientific": "Magnolia grandiflora 'D.D. Blanchard'",
+      "genus": "Magnolia grandiflora 'D.D. Blanchard'"
+    },
+    {
+      "common": "DEAD TREE",
+      "scientific": "Dead Tree",
+      "genus": "Dead "
+    },
+    {
+      "common": "deodar cedar",
+      "scientific": "Cedrus deodara",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Deodar Cedar",
+      "scientific": "Cedrus deodara",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Deodar Cedar",
+      "scientific": "Cedrus deodara",
+      "genus": "Cedrus deodara"
+    },
+    {
+      "common": "DEODAR CEDAR",
+      "scientific": "Cedrus deodara",
+      "genus": "Cedrus "
+    },
+    {
+      "common": "Dichotomanthes",
+      "scientific": "Dichotomanthes tristaniicarpa",
+      "genus": "Dichotomanthes "
+    },
+    {
+      "common": "Dogwood",
+      "scientific": "Cornus species",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood",
+      "scientific": "Cornus SPP",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood",
+      "scientific": "Cornus SPP",
+      "genus": "Cornus SPP"
+    },
+    {
+      "common": "DOGWOOD",
+      "scientific": "Cornus spp.",
+      "genus": "Cornus "
+    },
+    {
+      "common": "dogwood 'Eddie's White Wonder'",
+      "scientific": "Cornus 'Eddie's White Wonder'",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood, Flowering",
+      "scientific": "Cornus florida",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood, Himalayan Flowering",
+      "scientific": "Cornus capitata",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood, Kousa",
+      "scientific": "Cornus kousa",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Dogwood, Pacific",
+      "scientific": "Cornus nuttallii",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Douglas Fir",
+      "scientific": "Pseudotsuga menziesii",
+      "genus": "Pseudotsuga "
+    },
+    {
+      "common": "Douglas Fir",
+      "scientific": "Pseudotsuga menziesii",
+      "genus": "Pseudotsuga menziesii"
+    },
+    {
+      "common": "DOUGLAS FIR",
+      "scientific": "Pseudotsuga menziesii",
+      "genus": "Pseudotsuga "
+    },
+    {
+      "common": "Dracaena, Giant",
+      "scientific": "Cordyline australis",
+      "genus": "Cordyline "
+    },
+    {
+      "common": "Dracena Palm",
+      "scientific": "Cordyline australis",
+      "genus": "Cordyline "
+    },
+    {
+      "common": "Dracena Palm",
+      "scientific": "Cordyline australis",
+      "genus": "Cordyline australis"
+    },
+    {
+      "common": "Dragon tree",
+      "scientific": "Paulownia fortunei",
+      "genus": "Paulownia "
+    },
+    {
+      "common": "Dragon tree",
+      "scientific": "Paulownia fortunei",
+      "genus": "Paulownia fortunei"
+    },
+    {
+      "common": "Dragon Tree",
+      "scientific": "Dracaena draco",
+      "genus": "Dracaena "
+    },
+    {
+      "common": "Dragon Tree",
+      "scientific": "Dracaena draco",
+      "genus": "Dracaena draco"
+    },
+    {
+      "common": "DRAKE ELM",
+      "scientific": "Ulmus parvifolia Drake",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Drake's Chinese Elm",
+      "scientific": "Ulmus parvifolia 'Drake'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Drake's Chinese Elm",
+      "scientific": "Ulmus parvifolia 'Drake'",
+      "genus": "Ulmus parvifolia 'Drake'"
+    },
+    {
+      "common": "Dr. Hurd Manzanita",
+      "scientific": "Arctostaphylos manzanita 'Dr Hurd'",
+      "genus": "Arctostaphylos manzanita 'Dr Hurd'"
+    },
+    {
+      "common": "Drumstick tree",
+      "scientific": "Moringa oleifera",
+      "genus": "Moringa "
+    },
+    {
+      "common": "Dwarf strawberry tree",
+      "scientific": "Arbutus unedo 'Compacta'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Dwarf strawberry tree",
+      "scientific": "Arbutus unedo 'Compacta'",
+      "genus": "Arbutus unedo 'Compacta'"
+    },
+    {
+      "common": "Eastern black walnut",
+      "scientific": "Juglans nigra",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Eastern black walnut",
+      "scientific": "Juglans nigra",
+      "genus": "Juglans nigra"
+    },
+    {
+      "common": "Eastern cottonwood",
+      "scientific": "Populus deltoides",
+      "genus": "Populus "
+    },
+    {
+      "common": "Eastern Dogwood",
+      "scientific": "Cornus florida",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Eastern Dogwood",
+      "scientific": "Cornus florida",
+      "genus": "Cornus florida"
+    },
+    {
+      "common": "EASTERN DOGWOOD",
+      "scientific": "Cornus florida",
+      "genus": "Cornus "
+    },
+    {
+      "common": "Eastern Plane Tree",
+      "scientific": "Platanus orientalis",
+      "genus": "Platanus orientalis"
+    },
+    {
+      "common": "Eastern Redbud",
+      "scientific": "Cercis canadensis",
+      "genus": "Cercis"
+    },
+    {
+      "common": "Eastern Redbud",
+      "scientific": "Cercis canadensis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Eastern Redbud",
+      "scientific": "Cercis canadensis",
+      "genus": "Cercis canadensis"
+    },
+    {
+      "common": "EASTERN REDBUD",
+      "scientific": "Cercis canadensis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Eastern Redbud Forest Pansy",
+      "scientific": "Unknown Tree",
+      "genus": "Unknown "
+    },
+    {
+      "common": "Eastern white pine",
+      "scientific": "Pinus strobus",
+      "genus": "Pinus strobus"
+    },
+    {
+      "common": "Eddie's White Wonder Dogwood",
+      "scientific": "Cornus nuttallii x florida 'Eddie's White Wonder'",
+      "genus": "Cornus nuttallii x florida 'Eddie's White Wonder'"
+    },
+    {
+      "common": "EDIBLE APPLE",
+      "scientific": "Malus domestica",
+      "genus": "Malus "
+    },
+    {
+      "common": "Edible Fig",
+      "scientific": "Ficus carica",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Edible Fig",
+      "scientific": "Ficus carica",
+      "genus": "Ficus carica"
+    },
+    {
+      "common": "EDIBLE FIG",
+      "scientific": "Ficus carica",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Edible Loquat",
+      "scientific": "Eriobotrya japonica",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Edible Loquat",
+      "scientific": "Eriobotrya japonica",
+      "genus": "Eriobotrya japonica"
+    },
+    {
+      "common": "EDIBLE LOQUAT",
+      "scientific": "Eriobotrya japonica",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Elaeagnus",
+      "scientific": "Elaeagnus species",
+      "genus": "Elaeagnus "
+    },
+    {
+      "common": "Elderberry",
+      "scientific": "Sambucus species",
+      "genus": "Sambucus "
+    },
+    {
+      "common": "Elderberry",
+      "scientific": "Sambucus species",
+      "genus": "Sambucus species"
+    },
+    {
+      "common": "Elderberry, European Black",
+      "scientific": "Sambucus nigra",
+      "genus": "Sambucus "
+    },
+    {
+      "common": "Elm",
+      "scientific": "Ulmus species",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, American",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Chinese",
+      "scientific": "Ulmus parvifolia",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, English",
+      "scientific": "Ulmus procera",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Hybrid",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Hybrid",
+      "scientific": "Ulmus americana 'Jefferson'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Hybrid",
+      "scientific": "Ulmus americana 'New Harmony' (American elm) 10#",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Hybrid",
+      "scientific": "Ulmus x",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Rock",
+      "scientific": "Ulmus thomasii",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Siberian",
+      "scientific": "Ulmus pumila",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm, Slippery",
+      "scientific": "Ulmus rubra",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "ELM SPECIES",
+      "scientific": "Ulmus spp.",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm Spp",
+      "scientific": "Ulmus spp",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Elm Spp",
+      "scientific": "Ulmus spp",
+      "genus": "Ulmus spp"
+    },
+    {
+      "common": "Elm, Winged",
+      "scientific": "Ulmus alata",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Arborvitae",
+      "scientific": "Thuja occidentalis 'Emerald'",
+      "genus": "Thuja "
+    },
+    {
+      "common": "Emerald Arborvitae",
+      "scientific": "Thuja occidentalis 'Emerald'",
+      "genus": "Thuja occidentalis 'Emerald'"
+    },
+    {
+      "common": "Emerald Sunshine elm",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine elm",
+      "scientific": "Ulmus davidiana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine elm",
+      "scientific": "Ulmus propinqua 'Emerald Sunshine'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine elm",
+      "scientific": "Ulmus x",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine Elm",
+      "scientific": "Ulmus americana",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine Elm",
+      "scientific": "Ulmus propinqua 'Emerald Sunshine'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald Sunshine Elm",
+      "scientific": "Ulmus propinqua 'Emerald Sunshine'",
+      "genus": "Ulmus propinqua 'Emerald Sunshine'"
+    },
+    {
+      "common": "Emerald Sunshine Elm",
+      "scientific": "Ulmus propinqua Emerald Sunshine",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "EMERALD SUNSHINE ELM",
+      "scientific": "Ulmus propinqua JFS-Bieberich",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Emerald tree",
+      "scientific": "Radermachera sinica",
+      "genus": "Radermachera "
+    },
+    {
+      "common": "Empress Tree",
+      "scientific": "Paulownia tomentosa",
+      "genus": "Paulownia "
+    },
+    {
+      "common": "Empress Tree",
+      "scientific": "Paulownia tomentosa",
+      "genus": "Paulownia tomentosa"
+    },
+    {
+      "common": "Engelmann oak",
+      "scientific": "Quercus engelmannii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Engelmann oak",
+      "scientific": "Quercus engelmannii",
+      "genus": "Quercus engelmannii"
+    },
+    {
+      "common": "English Elm",
+      "scientific": "Ulmus procera",
+      "genus": "Ulmus procera"
+    },
+    {
+      "common": "English Hawthorn",
+      "scientific": "Crataegus laevigata",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "English Hawthorn",
+      "scientific": "Crataegus laevigata",
+      "genus": "Crataegus laevigata"
+    },
+    {
+      "common": "ENGLISH HAWTHORN",
+      "scientific": "Crataegus laevigata",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "English laurel",
+      "scientific": "Prunus laurocerasus",
+      "genus": "Prunus "
+    },
+    {
+      "common": "English laurel",
+      "scientific": "Prunus laurocerasus",
+      "genus": "Prunus laurocerasus"
+    },
+    {
+      "common": "ENGLISH LAUREL",
+      "scientific": "Prunus laurocerasus",
+      "genus": "Prunus "
+    },
+    {
+      "common": "English Oak",
+      "scientific": "Quercus robur",
+      "genus": "Quercus "
+    },
+    {
+      "common": "English Oak",
+      "scientific": "Quercus robur",
+      "genus": "Quercus robur"
+    },
+    {
+      "common": "ENGLISH OAK",
+      "scientific": "Quercus robur",
+      "genus": "Quercus "
+    },
+    {
+      "common": "ENGLISH WALNUT",
+      "scientific": "Juglans regia",
+      "genus": "Juglans "
+    },
+    {
+      "common": "ENGLISH YEW",
+      "scientific": "Taxus baccata",
+      "genus": "Taxus "
+    },
+    {
+      "common": "Espresso Kentucky coffeetree",
+      "scientific": "Gymnocladus dioica 'Espresso'",
+      "genus": "Gymnocladus "
+    },
+    {
+      "common": "Eucalyptus",
+      "scientific": "Eucalyptus species",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus",
+      "scientific": "Eucalyptus Spp",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus",
+      "scientific": "Eucalyptus Spp",
+      "genus": "Eucalyptus Spp"
+    },
+    {
+      "common": "EUCALYPTUS",
+      "scientific": "Eucalyptus spp.",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Blue Gum",
+      "scientific": "Eucalyptus globulus",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Desert Gum",
+      "scientific": "Eucalyptus rudis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Flooded Gum",
+      "scientific": "Eucalyptus grandis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Red gum",
+      "scientific": "Eucalyptus camaldulensis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Ribbon Gum",
+      "scientific": "Eucalyptus viminalis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Silver Dollar",
+      "scientific": "Eucalyptus cinerea",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eucalyptus, Sliver Dollar Gum",
+      "scientific": "Eucalyptus polyanthemos",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Eugenia",
+      "scientific": "Syzygium australe",
+      "genus": "Syzygium "
+    },
+    {
+      "common": "Eugenia",
+      "scientific": "Syzygium australe",
+      "genus": "Syzygium australe"
+    },
+    {
+      "common": "EUGENIA",
+      "scientific": "Syzygium spp.",
+      "genus": "Syzygium "
+    },
+    {
+      "common": "Eureka lemon",
+      "scientific": "Citrus x limon 'Eureka'",
+      "genus": "Citrus"
+    },
+    {
+      "common": "European Beech",
+      "scientific": "Fagus sylvatica",
+      "genus": "Fagus "
+    },
+    {
+      "common": "European Beech",
+      "scientific": "Fagus sylvatica",
+      "genus": "Fagus sylvatica"
+    },
+    {
+      "common": "European Hackberry",
+      "scientific": "Celtis australis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "European Hackberry",
+      "scientific": "Celtis australis",
+      "genus": "Celtis australis"
+    },
+    {
+      "common": "European Holly",
+      "scientific": "Ilex aquifolium",
+      "genus": "Ilex "
+    },
+    {
+      "common": "European Holly",
+      "scientific": "Ilex aquifolium",
+      "genus": "Ilex aquifolium"
+    },
+    {
+      "common": "European hornbeam",
+      "scientific": "Carpinus betulus 'Fastigiata'",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "European hornbeam",
+      "scientific": "Carpinus betulus 'Frans Fontaine'",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "European Hornbeam",
+      "scientific": "Carpinus betulus",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "European Hornbeam",
+      "scientific": "Carpinus betulus",
+      "genus": "Carpinus betulus"
+    },
+    {
+      "common": "EUROPEAN HORNBEAM",
+      "scientific": "Carpinus betulus",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "EUROPEAN LINDEN",
+      "scientific": "Tilia europaea",
+      "genus": "Tilia "
+    },
+    {
+      "common": "EUROPEAN MOUNTAIN ASH",
+      "scientific": "Sorbus acuparia",
+      "genus": "Sorbus "
+    },
+    {
+      "common": "European Mountain Ash Tr",
+      "scientific": "Sorbus aucuparia",
+      "genus": "Sorbus aucuparia"
+    },
+    {
+      "common": "European White Birch",
+      "scientific": "Betula pendula",
+      "genus": "Betula "
+    },
+    {
+      "common": "European White Birch",
+      "scientific": "Betula pendula",
+      "genus": "Betula pendula"
+    },
+    {
+      "common": "Evelyn hedge maple",
+      "scientific": "Acer campestre",
+      "genus": "Acer "
+    },
+    {
+      "common": "Evergreen Maple",
+      "scientific": "Acer paxii",
+      "genus": "Acer "
+    },
+    {
+      "common": "Evergreen Pear",
+      "scientific": "Pyrus kawakamii",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Evergreen Pear",
+      "scientific": "Pyrus kawakamii",
+      "genus": "Pyrus kawakamii"
+    },
+    {
+      "common": "EVERGREEN PEAR",
+      "scientific": "Pyrus kawakamii",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Evie Coast Silktassel Tree",
+      "scientific": "Garrya elliptica 'Evie'",
+      "genus": "Garrya "
+    },
+    {
+      "common": "Evie Coast Silktassel Tree",
+      "scientific": "Garrya elliptica 'Evie'",
+      "genus": "Garrya elliptica 'Evie'"
+    },
+    {
+      "common": "FAGUS SPECIES",
+      "scientific": "Fagus spp.",
+      "genus": "Fagus "
+    },
+    {
+      "common": "Fairmont Ginkgo",
+      "scientific": "Ginkgo biloba 'Fairmont'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Fairmont Ginkgo",
+      "scientific": "Ginkgo biloba 'Fairmont'",
+      "genus": "Ginkgo biloba 'Fairmont'"
+    },
+    {
+      "common": "FAIRMONT GINKGO",
+      "scientific": "Ginkgo biloba Fairmont",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "False Avocado",
+      "scientific": "Persea borbonia",
+      "genus": "Persea "
+    },
+    {
+      "common": "False Avocado",
+      "scientific": "Persea borbonia",
+      "genus": "Persea borbonia"
+    },
+    {
+      "common": "False Cypress, Hinoki",
+      "scientific": "Chamaecyparis obtusa",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "False Cypress, Sawara",
+      "scientific": "Chamaecyparis pisifera",
+      "genus": "Chamaecyparis "
+    },
+    {
+      "common": "FERN-LEAF CATALINA IRONWOOD",
+      "scientific": "Lyonothamnus floribundus",
+      "genus": "Lyonothamnus "
+    },
+    {
+      "common": "Fern Pine",
+      "scientific": "Afrocarpus gracilior",
+      "genus": "Afrocarpus "
+    },
+    {
+      "common": "Fern Pine",
+      "scientific": "Afrocarpus gracilior",
+      "genus": "Afrocarpus gracilior"
+    },
+    {
+      "common": "Fern Pine",
+      "scientific": "Podocarpus gracilor",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "Fern Pine",
+      "scientific": "Podocarpus gracilor",
+      "genus": "Podocarpus gracilor"
+    },
+    {
+      "common": "FERN PINE",
+      "scientific": "Afrocarpus gracilior",
+      "genus": "Afrocarpus "
+    },
+    {
+      "common": "Festival Sweet Gum",
+      "scientific": "Liquidambar styraciflua 'Festival'",
+      "genus": "Liquidambar styraciflua 'Festival'"
+    },
+    {
+      "common": "Ficus laurel",
+      "scientific": "Ficus laurel",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Ficus laurel",
+      "scientific": "Ficus laurel",
+      "genus": "Ficus laurel"
+    },
+    {
+      "common": "Ficus Spp.",
+      "scientific": "Ficus Spp.",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Ficus Spp.",
+      "scientific": "Ficus Spp.",
+      "genus": "Ficus Spp."
+    },
+    {
+      "common": "FIG",
+      "scientific": "Ficus spp.",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Fig, Benjamin",
+      "scientific": "Ficus benjamina",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Fig, Common",
+      "scientific": "Ficus carica",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Fig, Moreton Bay",
+      "scientific": "Ficus macrophylla",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Fig, Rustyleaf",
+      "scientific": "Ficus rubiginosa",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Filbert, European",
+      "scientific": "Corylus avellana",
+      "genus": "Corylus "
+    },
+    {
+      "common": "FIR",
+      "scientific": "Abies spp.",
+      "genus": "Abies "
+    },
+    {
+      "common": "Fir, Douglas",
+      "scientific": "Pseudotsuga menziesii",
+      "genus": "Pseudotsuga "
+    },
+    {
+      "common": "Fire Thorn",
+      "scientific": "Pyracantha coccinea",
+      "genus": "Pyracantha "
+    },
+    {
+      "common": "FIRETHORN",
+      "scientific": "Pyracantha coccinea",
+      "genus": "Pyracantha "
+    },
+    {
+      "common": "FIRETHORN",
+      "scientific": "Pyracantha spp.",
+      "genus": "Pyracantha "
+    },
+    {
+      "common": "Firethorn Tree 'Santa Cruz'",
+      "scientific": "Pyracantha  'Santa Cruz'",
+      "genus": "Pyracantha "
+    },
+    {
+      "common": "Firethorn Tree 'Santa Cruz'",
+      "scientific": "Pyracantha  'Santa Cruz'",
+      "genus": "Pyracantha  'Santa Cruz'"
+    },
+    {
+      "common": "Firewheel tree",
+      "scientific": "Stenocarpus sinuatus",
+      "genus": "Stenocarpus "
+    },
+    {
+      "common": "Firewheel Tree",
+      "scientific": "Stenocarpus sinuatus",
+      "genus": "Stenocarpus "
+    },
+    {
+      "common": "Fir, Grand",
+      "scientific": "Abies grandis",
+      "genus": "Abies "
+    },
+    {
+      "common": "Five finger",
+      "scientific": "Pseudopanax lessonii",
+      "genus": "Pseudopanax "
+    },
+    {
+      "common": "Flame Tree, Chinese",
+      "scientific": "Koelreuteria bipinnata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Flannelbush, California",
+      "scientific": "Fremontodendron californicum",
+      "genus": "Fremontodendron "
+    },
+    {
+      "common": "Flannel Bush Tree",
+      "scientific": "Fremontodendron spp",
+      "genus": "Fremontodendron "
+    },
+    {
+      "common": "Flannel Bush Tree",
+      "scientific": "Fremontodendron spp",
+      "genus": "Fremontodendron spp"
+    },
+    {
+      "common": "flaxleaf paperbark",
+      "scientific": "Melaleuca linariifolia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "flaxleaf paperbark",
+      "scientific": "Melaleuca linariifolia (flaxleaf paperbark)",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Flaxleaf Paperbark",
+      "scientific": "Melaleuca linariifolia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Flaxleaf Paperbark",
+      "scientific": "Melaleuca linariifolia",
+      "genus": "Melaleuca linariifolia"
+    },
+    {
+      "common": "Flooded Box: Coolibah",
+      "scientific": "Eucalyptus microtheca",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Flooded Box: Coolibah",
+      "scientific": "Eucalyptus microtheca",
+      "genus": "Eucalyptus microtheca"
+    },
+    {
+      "common": "floss silk tree",
+      "scientific": "Ceiba speciosa",
+      "genus": "Ceiba "
+    },
+    {
+      "common": "floss silk tree",
+      "scientific": "Ceiba speciosa (floss silk tree)",
+      "genus": "Ceiba "
+    },
+    {
+      "common": "floss silk tree",
+      "scientific": "Chorisia speciosa (floss silk tree)",
+      "genus": "Chorisia "
+    },
+    {
+      "common": "Floss Silk Tree",
+      "scientific": "Ceiba speciosa",
+      "genus": "Ceiba "
+    },
+    {
+      "common": "Flowering Ash",
+      "scientific": "Fraxinus ornus",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Flowering Ash",
+      "scientific": "Fraxinus ornus",
+      "genus": "Fraxinus ornus"
+    },
+    {
+      "common": "Flowering Cherry",
+      "scientific": "Prunus x 'Amanogawa'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Cherry",
+      "scientific": "Prunus x 'Amanogawa'",
+      "genus": "Prunus x 'Amanogawa'"
+    },
+    {
+      "common": "FLOWERING CHERRY",
+      "scientific": "Prunus campanulata",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Cherry Tree 'Amanagawa'",
+      "scientific": "Prunus serrulata 'Amanagawa'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Cherry Tree 'Amanagawa'",
+      "scientific": "Prunus serrulata 'Amanagawa'",
+      "genus": "Prunus serrulata 'Amanagawa'"
+    },
+    {
+      "common": "FLOWERING CRABAPPLE",
+      "scientific": "Malus purpurea",
+      "genus": "Malus "
+    },
+    {
+      "common": "Flowering maple",
+      "scientific": "Abutilon hybridum",
+      "genus": "Abutilon "
+    },
+    {
+      "common": "Flowering maple",
+      "scientific": "Abutilon hybridum",
+      "genus": "Abutilon hybridum"
+    },
+    {
+      "common": "Flowering Nectarine Tree",
+      "scientific": "Prunus persica nectarina",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Plum",
+      "scientific": "Prunus blireiana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Plum",
+      "scientific": "Prunus blireiana",
+      "genus": "Prunus blireiana"
+    },
+    {
+      "common": "Flowering Plum",
+      "scientific": "Prunus spp",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Flowering Plum",
+      "scientific": "Prunus spp",
+      "genus": "Prunus spp"
+    },
+    {
+      "common": "FLOWERNG CHERRY",
+      "scientific": "Prunus subhirtella",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Forest Pansy Redbud",
+      "scientific": "Cercis canadensis 'Forest Pansy'",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Forest Pansy Redbud",
+      "scientific": "Cercis canadensis 'Forest Pansy'",
+      "genus": "Cercis canadensis 'Forest Pansy'"
+    },
+    {
+      "common": "FOREST PANSY REDBUD",
+      "scientific": "Cercis canadensis Forest Pansy",
+      "genus": "Cercis "
+    },
+    {
+      "common": "FOUNTAIN PALM",
+      "scientific": "Livistona spp.",
+      "genus": "Livistona "
+    },
+    {
+      "common": "Foxtail palm",
+      "scientific": "Wodyetia bifurcata",
+      "genus": "Wodyetia bifurcata"
+    },
+    {
+      "common": "Fragipani, Sweetshade; Australian",
+      "scientific": "Hymenosporum flavum",
+      "genus": "Hymenosporum "
+    },
+    {
+      "common": "FRASERS PHOTINIA",
+      "scientific": "Photinia X fraseri",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Freeman Maple",
+      "scientific": "Acer x freemanii",
+      "genus": "Acer "
+    },
+    {
+      "common": "Freeman Maple",
+      "scientific": "Acer x freemanii",
+      "genus": "Acer x freemanii"
+    },
+    {
+      "common": "Fremont cottonwood",
+      "scientific": "Populus fremontii",
+      "genus": "Populus "
+    },
+    {
+      "common": "FREMONT COTTONWOOD",
+      "scientific": "Populus fremontii",
+      "genus": "Populus "
+    },
+    {
+      "common": "Fringe Tree",
+      "scientific": "Chionanthus virginicus",
+      "genus": "Chionanthus "
+    },
+    {
+      "common": "Fringe Tree, Chinese",
+      "scientific": "Chionanthus retusus",
+      "genus": "Chionanthus "
+    },
+    {
+      "common": "Frontier elm",
+      "scientific": "Ulmus 'Frontier'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier elm",
+      "scientific": "Ulmus x ' Frontier'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier elm",
+      "scientific": "Ulmus x 'Frontier'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier elm",
+      "scientific": "ulmus x frontier Frontier Hybrid Elm",
+      "genus": "ulmus "
+    },
+    {
+      "common": "Frontier elm",
+      "scientific": "Ulmus x 'Frontier' (Frontier Hybrid Elm)",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier Elm",
+      "scientific": "Ulmus 'Frontier'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier Elm",
+      "scientific": "Ulmus 'Frontier'",
+      "genus": "Ulmus 'Frontier'"
+    },
+    {
+      "common": "FRONTIER ELM",
+      "scientific": "Ulmus parvifolia Frontier",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier Elm 'Frontier'",
+      "scientific": "Ulmus carpinifolia 'Frontier'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Frontier Elm 'Frontier'",
+      "scientific": "Ulmus carpinifolia 'Frontier'",
+      "genus": "Ulmus carpinifolia 'Frontier'"
+    },
+    {
+      "common": "FRUITING PEAR",
+      "scientific": "Pyrus communis",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Fruitless Olive",
+      "scientific": "Olea europaea 'Fruitless'",
+      "genus": "Olea "
+    },
+    {
+      "common": "Fruitless Olive",
+      "scientific": "Olea europaea 'Fruitless'",
+      "genus": "Olea europaea 'Fruitless'"
+    },
+    {
+      "common": "Fuchsia species",
+      "scientific": "Fuchsia species",
+      "genus": "Fuchsia "
+    },
+    {
+      "common": "Fuyu persimmon",
+      "scientific": "Diospyros kaki 'Fuyu' Japanese Persimmon",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Fuyu persimmon",
+      "scientific": "Diospyros kaki 'Fuyu' (persimmon)",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Fuyu persimmon",
+      "scientific": "\"Diospyros kaki Japanese Persimmon (fuyu)\"",
+      "genus": "\"Diospyros "
+    },
+    {
+      "common": "Fuyu persimmon",
+      "scientific": "Fuyu persimmon",
+      "genus": "Fuyu "
+    },
+    {
+      "common": "Fuyu Persimmon",
+      "scientific": "Diospyros kaki",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Fuyu Persimmon",
+      "scientific": "Diospyros kaki 'Fuyu'",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Geijera",
+      "scientific": "Geijera spp",
+      "genus": "Geijera spp"
+    },
+    {
+      "common": "GIANT BIRD OF PARADISE",
+      "scientific": "Strelitzia nicolai",
+      "genus": "Strelitzia "
+    },
+    {
+      "common": "GIANT SEQUOIA",
+      "scientific": "Sequoiadendron giganteum",
+      "genus": "Sequoiadendron "
+    },
+    {
+      "common": "Giant Yucca",
+      "scientific": "Yucca elephantipes",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Giant Yucca",
+      "scientific": "Yucca elephantipes",
+      "genus": "Yucca elephantipes"
+    },
+    {
+      "common": "Gimlet, Narrow-Leaved",
+      "scientific": "Euonymus species",
+      "genus": "Euonymus "
+    },
+    {
+      "common": "Gimlet, Willow-Leaved",
+      "scientific": "Eucalyptus nicholii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "ginkgo",
+      "scientific": "Gingko biloba",
+      "genus": "Gingko "
+    },
+    {
+      "common": "ginkgo",
+      "scientific": "Ginkgo biloba Fairmont male",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "ginkgo",
+      "scientific": "\"Ginkgo Biloba \"\"The President\"\"\"",
+      "genus": "\"Ginkgo "
+    },
+    {
+      "common": "ginkgo",
+      "scientific": "Ginkgo biloba 'The President' (Presidential Gold ginkgo)",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Ginkgo",
+      "scientific": "Ginkgo biloba",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Ginkgo",
+      "scientific": "Ginkgo biloba 'Fairmont'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Ginkgo: Autumn Gold",
+      "scientific": "Ginkgo biloba 'Autumn Gold'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Ginkgo: Autumn Gold",
+      "scientific": "Ginkgo biloba 'Autumn Gold'",
+      "genus": "Ginkgo biloba 'Autumn Gold'"
+    },
+    {
+      "common": "Ginkgo: Saratoga",
+      "scientific": "Ginkgo biloba 'Saratoga'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Ginkgo: Saratoga",
+      "scientific": "Ginkgo biloba 'Saratoga'",
+      "genus": "Ginkgo biloba 'Saratoga'"
+    },
+    {
+      "common": "Globe Locust",
+      "scientific": "Robinia pseudoacacia 'Umbraculifera'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Glossy Privet",
+      "scientific": "Ligustrum lucidum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Glossy Privet",
+      "scientific": "Ligustrum lucidum",
+      "genus": "Ligustrum lucidum"
+    },
+    {
+      "common": "GLOSSY PRIVET",
+      "scientific": "Ligustrum lucidum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Golden Chinquapin",
+      "scientific": "Chrysolepis chrysophylla",
+      "genus": "Chrysolepis "
+    },
+    {
+      "common": "Golden Dewdrops",
+      "scientific": "Duranta erecta",
+      "genus": "Duranta "
+    },
+    {
+      "common": "goldenrain tree",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "goldenrain tree",
+      "scientific": "Koelreuteria paniculata 'Coral Sun' (Coral Sun goldenrain tree)",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "goldenrain tree",
+      "scientific": "Koelreuteria paniculata 'Summerburst'",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Goldenrain tree",
+      "scientific": "Koelreuteria paniculata 'Fastigiata'",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Goldenrain Tree",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Golden Rain Tree",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Golden Rain Tree",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria paniculata"
+    },
+    {
+      "common": "GOLDENRAIN TREE",
+      "scientific": "Koelreuteria paniculata",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Goldenrain Tree, Chinese",
+      "scientific": "Koelreuteria elegans",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Golden Wattle",
+      "scientific": "Acacia longifolia",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Golden Wattle",
+      "scientific": "Acacia longifolia",
+      "genus": "Acacia longifolia"
+    },
+    {
+      "common": "Gold Medallion Tree",
+      "scientific": "Cassia leptophylla",
+      "genus": "Cassia "
+    },
+    {
+      "common": "Gold Medallion Tree",
+      "scientific": "Cassia leptophylla",
+      "genus": "Cassia leptophylla"
+    },
+    {
+      "common": "Grapefruit",
+      "scientific": "Citrus x paradisi",
+      "genus": "Citrus "
+    },
+    {
+      "common": "GREEN ASH",
+      "scientific": "Fraxinus pennsylvanica",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "GREEN COLUMN MAPLE",
+      "scientific": "Acer nigrum Green Column",
+      "genus": "Acer "
+    },
+    {
+      "common": "Green Gable tupelo",
+      "scientific": "Nyssa sylvatica 'Green Gable' (tupelo)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Green Gage Plum",
+      "scientific": "Prunus domestica 'Green Gage'",
+      "genus": "Prunus domestica 'Green Gage'"
+    },
+    {
+      "common": "GREEN MOUNTAIN LINDEN",
+      "scientific": "Tilia tomentosa Green Mountain",
+      "genus": "Tilia "
+    },
+    {
+      "common": "GREENSPIRE LINDEN",
+      "scientific": "Tilia cordata Greenspire",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Greenstone elm",
+      "scientific": "Ulmus davidiana 'Greenstone'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Grevillea, Obtuse-leaved",
+      "scientific": "Grevillea obtusifolia",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Griselinia",
+      "scientific": "Griselinia littoralis",
+      "genus": "Griselinia "
+    },
+    {
+      "common": "Griselinia",
+      "scientific": "Griselinia lucida",
+      "genus": "Griselinia "
+    },
+    {
+      "common": "Guadalupe Palm",
+      "scientific": "Brahea edulis",
+      "genus": "Brahea "
+    },
+    {
+      "common": "Guadalupe Palm",
+      "scientific": "Brahea edulis",
+      "genus": "Brahea edulis"
+    },
+    {
+      "common": "Guava",
+      "scientific": "Psidium guajava",
+      "genus": "Psidium "
+    },
+    {
+      "common": "Guava, Pineapple",
+      "scientific": "Feijoa sellowiana",
+      "genus": "Feijoa "
+    },
+    {
+      "common": "Guava tree",
+      "scientific": "Psidium guajava",
+      "genus": "Psidium "
+    },
+    {
+      "common": "Guava tree",
+      "scientific": "Psidium guajava",
+      "genus": "Psidium guajava"
+    },
+    {
+      "common": "Gum Bumelia",
+      "scientific": "Sideroxylon lanuginosum",
+      "genus": "Sideroxylon "
+    },
+    {
+      "common": "Gum, Lemon-Scented",
+      "scientific": "Eucalyptus citriodora",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Gum, Red-Cap",
+      "scientific": "Eucalyptus erythrocorys",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Gum, Red Flowering",
+      "scientific": "Corymbia ficifolia",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "Gymnocladus dioica 'Espresso'",
+      "scientific": "Espresso Kentucky Coffeetree",
+      "genus": "Espresso "
+    },
+    {
+      "common": "Hachiya persimmon",
+      "scientific": "Diospyros kaki 'Hachiya' (persimmon)",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Hackberry",
+      "scientific": "Celtis species",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Hackberry, Chinese",
+      "scientific": "Celtis sinensis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Hackberry, European",
+      "scientific": "Celtis australis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Hackberry, Northern",
+      "scientific": "Celtis occidentalis",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Hackberry, Western",
+      "scientific": "Celtis reticulata",
+      "genus": "Celtis "
+    },
+    {
+      "common": "Hairy wattle",
+      "scientific": "Acacia vestita",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Hairy wattle",
+      "scientific": "Acacia vestita",
+      "genus": "Acacia vestita"
+    },
+    {
+      "common": "Hakea, Sweet; Scented",
+      "scientific": "Hakea suaveolens",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Hakea, Willow leaf",
+      "scientific": "Hakea salicifolia",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Hass avocado",
+      "scientific": "Persea americana 'Hass' (avocado)",
+      "genus": "Persea "
+    },
+    {
+      "common": "Hawthorn",
+      "scientific": "Crataegus species",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn",
+      "scientific": "Crateagus spp",
+      "genus": "Crateagus "
+    },
+    {
+      "common": "Hawthorn",
+      "scientific": "Crateagus spp",
+      "genus": "Crateagus spp"
+    },
+    {
+      "common": "HAWTHORN",
+      "scientific": "Crataegus spp.",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn, Black",
+      "scientific": "Crataegus douglasii",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn, Carriere",
+      "scientific": "Crataegus x Lavallei",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn, Green",
+      "scientific": "Crataegus viridis",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn, Indian",
+      "scientific": "Rhaphiolepis",
+      "genus": ""
+    },
+    {
+      "common": "Hawthorn, Smooth",
+      "scientific": "Crataegus laevigata",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Hawthorn, Washington",
+      "scientific": "Crataegus phaenopyrum",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "HAZELNUT",
+      "scientific": "Corylus spp.",
+      "genus": "Corylus "
+    },
+    {
+      "common": "Hazelnut, Turkish",
+      "scientific": "Corylus colurna",
+      "genus": "Corylus "
+    },
+    {
+      "common": "Hazel: Turkish",
+      "scientific": "Corylus colurna",
+      "genus": "Corylus "
+    },
+    {
+      "common": "Hazel: Turkish",
+      "scientific": "Corylus colurna",
+      "genus": "Corylus colurna"
+    },
+    {
+      "common": "Heath Melaleuca",
+      "scientific": "Melaleuca ericifolia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Heath Melaleuca",
+      "scientific": "Melaleuca ericifolia",
+      "genus": "Melaleuca ericifolia"
+    },
+    {
+      "common": "Hedge Maple",
+      "scientific": "Acer campestre",
+      "genus": "Acer campestre"
+    },
+    {
+      "common": "HEDGE MAPLE",
+      "scientific": "Acer campestre",
+      "genus": "Acer "
+    },
+    {
+      "common": "Helene Strybing New Zealand Tea Tree",
+      "scientific": "Leptospermum scoparium  'Helene Strybing'",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Helene Strybing New Zealand Tea Tree",
+      "scientific": "Leptospermum scoparium  'Helene Strybing'",
+      "genus": "Leptospermum scoparium  'Helene Strybing'"
+    },
+    {
+      "common": "Hemlock, Western",
+      "scientific": "Tsuga heterophylla",
+      "genus": "Tsuga "
+    },
+    {
+      "common": "Hibiscus, Chinese",
+      "scientific": "Hibiscus rosa-sinensis",
+      "genus": "Hibiscus "
+    },
+    {
+      "common": "Hickory, Pignut",
+      "scientific": "Carya glabra",
+      "genus": "Carya "
+    },
+    {
+      "common": "Higan Cherry",
+      "scientific": "Prunus subhirtella 'autumnalis'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Higan Cherry",
+      "scientific": "Prunus subhirtella 'autumnalis'",
+      "genus": "Prunus subhirtella 'autumnalis'"
+    },
+    {
+      "common": "Himalayan Fishtail Palm",
+      "scientific": "Caryota maxima 'Himalaya'",
+      "genus": "Caryota "
+    },
+    {
+      "common": "Himalayan Fishtail Palm",
+      "scientific": "Caryota maxima 'Himalaya'",
+      "genus": "Caryota maxima 'Himalaya'"
+    },
+    {
+      "common": "Himalayan Magnolia",
+      "scientific": "Magnolia doltsopa",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Himalayan Magnolia",
+      "scientific": "Magnolia doltsopa",
+      "genus": "Magnolia doltsopa"
+    },
+    {
+      "common": "Hinoki cypress",
+      "scientific": "Chamaecyparis obtusa",
+      "genus": "Chamaecyparis obtusa"
+    },
+    {
+      "common": "Holly",
+      "scientific": "Ilex species",
+      "genus": "Ilex "
+    },
+    {
+      "common": "HOLLY",
+      "scientific": "Ilex spp.",
+      "genus": "Ilex "
+    },
+    {
+      "common": "Holly, American",
+      "scientific": "Ilex opaca",
+      "genus": "Ilex "
+    },
+    {
+      "common": "Holly, English",
+      "scientific": "Ilex aquifolium",
+      "genus": "Ilex "
+    },
+    {
+      "common": "HOLLYLEAF CHERRY",
+      "scientific": "Prunus ilicifolia",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Holly-leaved Cherry",
+      "scientific": "Prunus ilicifoia",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Holly-leaved Cherry",
+      "scientific": "Prunus ilicifoia",
+      "genus": "Prunus ilicifoia"
+    },
+    {
+      "common": "Holly Oak",
+      "scientific": "Quercus ilex",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Holly Oak",
+      "scientific": "Quercus ilex",
+      "genus": "Quercus ilex"
+    },
+    {
+      "common": "Holly Oak",
+      "scientific": "Quercus ilex Holly Oak",
+      "genus": "Quercus "
+    },
+    {
+      "common": "HOLLY OAK",
+      "scientific": "Quercus ilex",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Holly Species",
+      "scientific": "Ilex spp",
+      "genus": "Ilex "
+    },
+    {
+      "common": "Holly Species",
+      "scientific": "Ilex spp",
+      "genus": "Ilex spp"
+    },
+    {
+      "common": "HOLLYWOOD JUNIPER",
+      "scientific": "Juniperus chinensis Torulosa",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Holotricha Ash",
+      "scientific": "Fraxinus holotricha",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Holotricha Ash",
+      "scientific": "Fraxinus holotricha",
+      "genus": "Fraxinus holotricha"
+    },
+    {
+      "common": "Honeylocust",
+      "scientific": "Gleditsia triacanthos",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey Locust",
+      "scientific": "Gleditsia triacanthos",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey Locust",
+      "scientific": "Gleditsia triacanthos",
+      "genus": "Gleditsia triacanthos"
+    },
+    {
+      "common": "HONEY LOCUST",
+      "scientific": "Gleditsia triacanthos",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey Locust 'Aurea'",
+      "scientific": "Gleditsia triacanthos 'Aurea'",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honeylocust, Imperial",
+      "scientific": "Gleditsia triacanthos 'Imperial'",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey Locust 'Shademaster'",
+      "scientific": "Gleditsia triacanthos 'Shademaster'",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey Locust 'Shademaster'",
+      "scientific": "Gleditsia triacanthos 'Shademaster'",
+      "genus": "Gleditsia triacanthos 'Shademaster'"
+    },
+    {
+      "common": "Honeylocust, Thornless",
+      "scientific": "Gleditsia triacanthos inermis",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Honey-myrtle, Bracelet",
+      "scientific": "Melaleuca armillaris",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Honeysuckle",
+      "scientific": "Lonicera species",
+      "genus": "Lonicera "
+    },
+    {
+      "common": "Hop Bush",
+      "scientific": "Dodonaea viscosa",
+      "genus": "Dodonaea "
+    },
+    {
+      "common": "Hop Bush",
+      "scientific": "Dodonaea viscosa",
+      "genus": "Dodonaea viscosa"
+    },
+    {
+      "common": "Hopbush, Florida",
+      "scientific": "Dodonaea viscosa",
+      "genus": "Dodonaea "
+    },
+    {
+      "common": "HOPSEED",
+      "scientific": "Dodonaea viscosa",
+      "genus": "Dodonaea "
+    },
+    {
+      "common": "HOPSEED BUSH PURPLE",
+      "scientific": "Dodonaea viscosa Purpurea",
+      "genus": "Dodonaea "
+    },
+    {
+      "common": "HORNBEAM",
+      "scientific": "Carpinus spp.",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Hornbeam, American",
+      "scientific": "Carpinus caroliniana",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Hornbeam, European",
+      "scientific": "Carpinus betulus",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Hornbeam, European 'Fastigiata'",
+      "scientific": "Carpinus betulus 'Fastigiata'",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Horsechestnut",
+      "scientific": "Aesculus hippocastanum",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Horsechestnut",
+      "scientific": "Aesculus spp",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "HORSECHESTNUT",
+      "scientific": "Aesculus spp.",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Horsechestnut, Red",
+      "scientific": "Aesculus x carnea",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Horsetail pine",
+      "scientific": "Casuarina cunninghamiana",
+      "genus": "Casuarina "
+    },
+    {
+      "common": "Horsetail pine",
+      "scientific": "Casuarina cunninghamiana",
+      "genus": "Casuarina cunninghamiana"
+    },
+    {
+      "common": "Hungarian Oak",
+      "scientific": "Quercus frainetto 'Trump'",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Hungarian Oak",
+      "scientific": "Quercus frainetto 'Trump'",
+      "genus": "Quercus frainetto 'Trump'"
+    },
+    {
+      "common": "HYBRID EUCALYPTUS",
+      "scientific": "Eucalyptus longifolia Robusta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Hybrid Laurel",
+      "scientific": "Laurus x 'Saratoga'",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Hybrid Laurel",
+      "scientific": "Laurus x 'Saratoga'",
+      "genus": "Laurus x 'Saratoga'"
+    },
+    {
+      "common": "hybrid madrone",
+      "scientific": "arbutus marina",
+      "genus": "arbutus "
+    },
+    {
+      "common": "hybrid madrone",
+      "scientific": "Arbutus marina",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "hybrid madrone",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "hybrid madrone",
+      "scientific": "Arbutus x 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Hybrid Madrone",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Hybrid Maple",
+      "scientific": "Acer x 'Autumn Blaze'",
+      "genus": "Acer x 'Autumn Blaze'"
+    },
+    {
+      "common": "Hybrid Monkey Hand Tree",
+      "scientific": "x Chiranthofremontia lenzii",
+      "genus": "x Chiranthofremontia lenzii"
+    },
+    {
+      "common": "Hybrid Strawberry Tree",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Hybrid Strawberry Tree",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus 'Marina'"
+    },
+    {
+      "common": "Hydrangea",
+      "scientific": "Hydrangea species",
+      "genus": "Hydrangea "
+    },
+    {
+      "common": "Idaho Pink Locust",
+      "scientific": "Robinia x ambigua 'Idahoensis'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Idaho Pink Locust",
+      "scientific": "Robinia x ambigua 'Idahoensis'",
+      "genus": "Robinia x ambigua 'Idahoensis'"
+    },
+    {
+      "common": "Improved Meyer Lemon",
+      "scientific": "Citrus �� meyeri 'Improved'",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Improved Meyer Lemon",
+      "scientific": "Citrus �� meyeri 'Improved'",
+      "genus": "Citrus �� meyeri 'Improved'"
+    },
+    {
+      "common": "incense cedar",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus "
+    },
+    {
+      "common": "incense cedar",
+      "scientific": "Calocedrus decurrens Incense Cedar",
+      "genus": "Calocedrus "
+    },
+    {
+      "common": "Incense Cedar",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus"
+    },
+    {
+      "common": "Incense Cedar",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus "
+    },
+    {
+      "common": "Incense Cedar",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus decurrens"
+    },
+    {
+      "common": "INCENSE CEDAR",
+      "scientific": "Calocedrus decurrens",
+      "genus": "Calocedrus "
+    },
+    {
+      "common": "India Hawthorn",
+      "scientific": "Rhaphiolepis indica",
+      "genus": "Rhaphiolepis "
+    },
+    {
+      "common": "India Hawthorn",
+      "scientific": "Rhaphiolepis indica",
+      "genus": "Rhaphiolepis indica"
+    },
+    {
+      "common": "Indian Bay",
+      "scientific": "Persea indica",
+      "genus": "Persea "
+    },
+    {
+      "common": "Indian Bay",
+      "scientific": "Persea indica",
+      "genus": "Persea indica"
+    },
+    {
+      "common": "INDIAN HAWTHORNE",
+      "scientific": "Rhaphiolepis Majestic Beauty",
+      "genus": "Rhaphiolepis "
+    },
+    {
+      "common": "Indian Hawthorn  'Majestic Beau'",
+      "scientific": "Rhaphiolepis Majestic Beauty",
+      "genus": "Rhaphiolepis "
+    },
+    {
+      "common": "Indian Hawthorn  'Majestic Beau'",
+      "scientific": "Rhaphiolepis Majestic Beauty",
+      "genus": "Rhaphiolepis Majestic Beauty"
+    },
+    {
+      "common": "INDIAN LAUREL FIG",
+      "scientific": "Ficus microcarpa Nitida",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Indian Laurel Fig Tree 'Green Gem'",
+      "scientific": "Ficus microcarpa nitida 'Green Gem'",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Indian Laurel Fig Tree 'Green Gem'",
+      "scientific": "Ficus microcarpa nitida 'Green Gem'",
+      "genus": "Ficus microcarpa nitida 'Green Gem'"
+    },
+    {
+      "common": "Indian Rubber Tree",
+      "scientific": "Ficus elastica",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Interior Live Oak",
+      "scientific": "Quercus wislizenii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Interior Live Oak",
+      "scientific": "Quercus wislizenii",
+      "genus": "Quercus wislizenii"
+    },
+    {
+      "common": "Irish Yew",
+      "scientific": "Taxus baccata",
+      "genus": "Taxus "
+    },
+    {
+      "common": "Irish Yew",
+      "scientific": "Taxus baccata",
+      "genus": "Taxus baccata"
+    },
+    {
+      "common": "Ironbark, Red",
+      "scientific": "Eucalyptus sideroxylon",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Ironbark, White",
+      "scientific": "Eucalyptus leucoxylon",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Ironwood, Persian",
+      "scientific": "Parrotia persica",
+      "genus": "Parrotia "
+    },
+    {
+      "common": "island oak",
+      "scientific": "Quercus tomentella",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Island oak",
+      "scientific": "Quercus tomentella",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Island oak",
+      "scientific": "Quercus tomentella",
+      "genus": "Quercus tomentella"
+    },
+    {
+      "common": "Island Oak",
+      "scientific": "Quercus tomentella",
+      "genus": "Quercus"
+    },
+    {
+      "common": "Italian Alder",
+      "scientific": "Alnus cordata",
+      "genus": "Alnus "
+    },
+    {
+      "common": "Italian Alder",
+      "scientific": "Alnus cordata",
+      "genus": "Alnus cordata"
+    },
+    {
+      "common": "ITALIAN ALDER",
+      "scientific": "Alnus cordata",
+      "genus": "Alnus "
+    },
+    {
+      "common": "Italian Buckthorn",
+      "scientific": "Rhamnus alaternus",
+      "genus": "Rhamnus "
+    },
+    {
+      "common": "Italian Buckthorn",
+      "scientific": "Rhamnus alaternus",
+      "genus": "Rhamnus alaternus"
+    },
+    {
+      "common": "Italian Cypress",
+      "scientific": "Cupressus sempervirens",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Italian Cypress",
+      "scientific": "Cupressus sempervirens",
+      "genus": "Cupressus sempervirens"
+    },
+    {
+      "common": "ITALIAN CYPRESS",
+      "scientific": "Cupressus sempervirens",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Italian Stone Pine",
+      "scientific": "Pinus pinea",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Italian Stone Pine",
+      "scientific": "Pinus pinea",
+      "genus": "Pinus pinea"
+    },
+    {
+      "common": "ITALIAN STONE PINE",
+      "scientific": "Pinus pinea",
+      "genus": "Pinus "
+    },
+    {
+      "common": "jacaranda",
+      "scientific": "Jacaranda mimosifolia",
+      "genus": "Jacaranda "
+    },
+    {
+      "common": "Jacaranda",
+      "scientific": "Jacaranda mimosifolia",
+      "genus": "Jacaranda "
+    },
+    {
+      "common": "Jacaranda",
+      "scientific": "Jacaranda mimosifolia",
+      "genus": "Jacaranda mimosifolia"
+    },
+    {
+      "common": "JACARANDA",
+      "scientific": "Jacaranda mimosifolia",
+      "genus": "Jacaranda "
+    },
+    {
+      "common": "Jack Fogg Michelia",
+      "scientific": "Magnolia x foggii 'Jack Fogg'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Jack Fogg Michelia",
+      "scientific": "Magnolia x foggii 'Jack Fogg'",
+      "genus": "Magnolia x foggii 'Jack Fogg'"
+    },
+    {
+      "common": "James Roof Coast Silktassel Tree",
+      "scientific": "Garrya elliptica 'James Roof'",
+      "genus": "Garrya "
+    },
+    {
+      "common": "Japanese Black Pine",
+      "scientific": "Pinus thunbergii",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Japanese Black Pine",
+      "scientific": "Pinus thunbergii",
+      "genus": "Pinus thunbergii"
+    },
+    {
+      "common": "JAPANESE BLACK PINE",
+      "scientific": "Pinus thunbergiana",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Japanese Blueberry Tree",
+      "scientific": "Elaeocarpus decipiens",
+      "genus": "Elaeocarpus "
+    },
+    {
+      "common": "Japanese Blueberry Tree",
+      "scientific": "Elaeocarpus decipiens",
+      "genus": "Elaeocarpus decipiens"
+    },
+    {
+      "common": "JAPANESE BLUEBERRY TREE",
+      "scientific": "Elaeocarpus decipiens",
+      "genus": "Elaeocarpus "
+    },
+    {
+      "common": "Japanese chinquapin",
+      "scientific": "Castanopsis cuspidata",
+      "genus": "Castanopsis "
+    },
+    {
+      "common": "Japanese Crape Myrtle",
+      "scientific": "Lagerstroemia fauriei",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Japanese Cryptomeria",
+      "scientific": "Cryptomeria japonica",
+      "genus": "Cryptomeria "
+    },
+    {
+      "common": "Japanese Cryptomeria",
+      "scientific": "Cryptomeria japonica",
+      "genus": "Cryptomeria japonica"
+    },
+    {
+      "common": "Japanese elm",
+      "scientific": "Zelkova serrata",
+      "genus": "Zelcova"
+    },
+    {
+      "common": "JAPANESE FLOWERING CHERRY",
+      "scientific": "Prunus serrulata",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Japanese Maple",
+      "scientific": "Acer japonicum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Japanese Maple",
+      "scientific": "Acer japonicum",
+      "genus": "Acer japonicum"
+    },
+    {
+      "common": "Japanese Maple",
+      "scientific": "Acer palmatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Japanese Maple",
+      "scientific": "Acer palmatum",
+      "genus": "Acer palmatum"
+    },
+    {
+      "common": "JAPANESE MAPLE",
+      "scientific": "Acer palmatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "JAPANESE MAPLE BLOODGOOD",
+      "scientific": "Acer palmatum Bloodgood",
+      "genus": "Acer "
+    },
+    {
+      "common": "Japanese Mockorange",
+      "scientific": "Pittosporum tobira",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Japanese Mockorange",
+      "scientific": "Pittosporum tobira",
+      "genus": "Pittosporum tobira"
+    },
+    {
+      "common": "Japanese Pagoda",
+      "scientific": "Sophora japonica",
+      "genus": "Sophora "
+    },
+    {
+      "common": "Japanese Pagoda",
+      "scientific": "Sophora japonica",
+      "genus": "Sophora japonica"
+    },
+    {
+      "common": "JAPANESE PAGODA TREE",
+      "scientific": "Styphnolobium japonicum",
+      "genus": "Styphnolobium "
+    },
+    {
+      "common": "Japanese Privet",
+      "scientific": "Ligustrum japonicum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Japanese Privet",
+      "scientific": "Ligustrum japonicum",
+      "genus": "Ligustrum japonicum"
+    },
+    {
+      "common": "Japanese Snowdrop Tree",
+      "scientific": "Styrax japonicus",
+      "genus": "Styrax japonicus"
+    },
+    {
+      "common": "JAPANESE TREE LILAC",
+      "scientific": "Syringa reticulata",
+      "genus": "Syringa "
+    },
+    {
+      "common": "Jefferson American elm",
+      "scientific": "Ulmus americana 'Jefferson'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Jerusalem Thorn",
+      "scientific": "Parkinsonia aculeata",
+      "genus": "Parkinsonia "
+    },
+    {
+      "common": "John Edwards Buckthorn",
+      "scientific": "Rhamnus alaternus 'John Edwards'",
+      "genus": "Rhamnus "
+    },
+    {
+      "common": "Jujube",
+      "scientific": "Ziziphus jujuba",
+      "genus": "Ziziphus "
+    },
+    {
+      "common": "Jujube",
+      "scientific": "Ziziphus jujuba",
+      "genus": "Ziziphus jujuba"
+    },
+    {
+      "common": "Juniper",
+      "scientific": "Juniperus chinensis",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper",
+      "scientific": "Juniperus chinensis",
+      "genus": "Juniperus chinensis"
+    },
+    {
+      "common": "Juniper",
+      "scientific": "Juniperus species",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "JUNIPER",
+      "scientific": "Juniperus spp.",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper, California",
+      "scientific": "Juniperus californica",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper, Chinese",
+      "scientific": "Juniperus chinensis",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper, Common",
+      "scientific": "Juniperus communis",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper, One Seed",
+      "scientific": "Juniperus monosperma",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper, Rocky Mountain",
+      "scientific": "Juniperus scopulorum",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Juniper Tree 'Pathfinder'",
+      "scientific": "Juniperus scopulorum 'Pat",
+      "genus": "Juniperus scopulorum 'Pat"
+    },
+    {
+      "common": "Juniper, Western",
+      "scientific": "Juniperus occidentalis",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Kaffir lime",
+      "scientific": "Citrus x hystrix",
+      "genus": "Citrus x hystrix"
+    },
+    {
+      "common": "Kanooka, Water Gum",
+      "scientific": "Tristaniopsis laurina",
+      "genus": "Tristaniopsis "
+    },
+    {
+      "common": "KARO",
+      "scientific": "Pittosporum crassifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Karo Tree",
+      "scientific": "Pittosporum crassifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Karo Tree",
+      "scientific": "Pittosporum crassifolium",
+      "genus": "Pittosporum crassifolium"
+    },
+    {
+      "common": "Katsura tree",
+      "scientific": "Cercidiphyllum japonicum",
+      "genus": "Cercidiphyllum "
+    },
+    {
+      "common": "Katsura Tree",
+      "scientific": "Cercidiphyllum japonicum",
+      "genus": "Cercidiphyllum "
+    },
+    {
+      "common": "KEITH DAVEY PISTACHE",
+      "scientific": "Pistacia chinensis Keith Davey",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Kelakid",
+      "scientific": "Ceratonia siliqua",
+      "genus": "Ceratonia "
+    },
+    {
+      "common": "Kentia Palm",
+      "scientific": "Howea forsteriana",
+      "genus": "Howea "
+    },
+    {
+      "common": "Kentia Palm",
+      "scientific": "Howea forsteriana",
+      "genus": "Howea forsteriana"
+    },
+    {
+      "common": "KENTUCKY COFFEE TREE",
+      "scientific": "Gymnocladus dioicus",
+      "genus": "Gymnocladus "
+    },
+    {
+      "common": "King Palm",
+      "scientific": "Archontophoenix cunninghamiana",
+      "genus": "Archontophoenix "
+    },
+    {
+      "common": "King Palm",
+      "scientific": "Archontophoenix cunninghamiana",
+      "genus": "Archontophoenix cunninghamiana"
+    },
+    {
+      "common": "KOELREUTERIA",
+      "scientific": "Koelreuteria spp.",
+      "genus": "Koelreuteria "
+    },
+    {
+      "common": "Kumquat",
+      "scientific": "Fortunella margarita",
+      "genus": "Fortunella "
+    },
+    {
+      "common": "Kumquat",
+      "scientific": "Fortunella margarita",
+      "genus": "Fortunella margarita"
+    },
+    {
+      "common": "KUMQUAT",
+      "scientific": "Fortunella margarita",
+      "genus": "Fortunella "
+    },
+    {
+      "common": "Kwanzan Flowering Cherry",
+      "scientific": "Prunus serrulata 'Kwanzan'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Kwanzan Flowering Cherry",
+      "scientific": "Prunus serrulata 'Kwanzan'",
+      "genus": "Prunus serrulata 'Kwanzan'"
+    },
+    {
+      "common": "Lagerstroemia x 'Muskogee'",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Lagerstroemia x 'Natchez'",
+      "scientific": "Lagerstroemia indica",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Laurel, California",
+      "scientific": "Umbellularia californica",
+      "genus": "Umbellularia "
+    },
+    {
+      "common": "Laurelcherry, Carolina",
+      "scientific": "Prunus caroliniana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Laurel, Common Cherry",
+      "scientific": "Prunus laurocerasus",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Laurel Fig",
+      "scientific": "Ficus nitida",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Laurel Fig",
+      "scientific": "Ficus nitida",
+      "genus": "Ficus nitida"
+    },
+    {
+      "common": "Laurus nobilis 'Saratoga'",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Lebanon cedar",
+      "scientific": "Cedrus libani",
+      "genus": "Cedrus libani"
+    },
+    {
+      "common": "Lemon",
+      "scientific": "Citrus limon",
+      "genus": "Citrus "
+    },
+    {
+      "common": "LEMON",
+      "scientific": "Citrus limon",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Lemon Bottlebrush",
+      "scientific": "Callistemon citrinus",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Lemon Bottlebrush",
+      "scientific": "Callistemon citrinus",
+      "genus": "Callistemon citrinus"
+    },
+    {
+      "common": "LEMON BOTTLEBRUSH",
+      "scientific": "Melaleuca citrina",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Lemon: Orange: Lime",
+      "scientific": "Citrus spp",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Lemon: Orange: Lime",
+      "scientific": "Citrus spp",
+      "genus": "Citrus spp"
+    },
+    {
+      "common": "Lemon scented eucalyptus",
+      "scientific": "Eucalyptus citriodora",
+      "genus": "Eucalyptus citriodora"
+    },
+    {
+      "common": "Lemon Scented Gum",
+      "scientific": "Corymbia citriodora",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "Lemon Scented Gum",
+      "scientific": "Corymbia citriodora",
+      "genus": "Corymbia citriodora"
+    },
+    {
+      "common": "Lemon Scented Tea Tree",
+      "scientific": "Leptospermum petersonii",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Lemon Scented Tea Tree",
+      "scientific": "Leptospermum petersonii",
+      "genus": "Leptospermum petersonii"
+    },
+    {
+      "common": "Leyland Cypress",
+      "scientific": "Cupressocyparis leylandii",
+      "genus": "Cupressocyparis "
+    },
+    {
+      "common": "Leyland Cypress",
+      "scientific": "Cupressocyparis leylandii",
+      "genus": "Cupressocyparis leylandii"
+    },
+    {
+      "common": "LEYLAND CYPRESS",
+      "scientific": "Cupressocyparis x leylandii",
+      "genus": "Cupressocyparis "
+    },
+    {
+      "common": "Lilac, Common",
+      "scientific": "Syringa vulgaris",
+      "genus": "Syringa "
+    },
+    {
+      "common": "Lilac Tree",
+      "scientific": "Syringa",
+      "genus": ""
+    },
+    {
+      "common": "Lilac Tree",
+      "scientific": "Syringa",
+      "genus": "Syringa"
+    },
+    {
+      "common": "Lily-of-the-Valley Tree",
+      "scientific": "Crinodendron patagua",
+      "genus": "Crinodendron patagua"
+    },
+    {
+      "common": "Lime",
+      "scientific": "Citrus aurantifolia",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Linden",
+      "scientific": "Tilia spp",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Linden",
+      "scientific": "Tilia spp",
+      "genus": "Tilia spp"
+    },
+    {
+      "common": "LINDEN",
+      "scientific": "Tilia spp.",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Linden, Bigleaf",
+      "scientific": "Tilia platyphyllos",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Linden, Littleleaf",
+      "scientific": "Tilia cordata",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Linden,Littleleaf 'Greenspire'",
+      "scientific": "Tilia cordata 'Greenspire'",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Linden, Silver",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Lisbon Lemon Tree",
+      "scientific": "Citrus �� limon 'Lisbon'",
+      "genus": "Citrus �� limon 'Lisbon'"
+    },
+    {
+      "common": "Little Gem Magnolia",
+      "scientific": "Magnolia grandiflora 'Little Gem'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Little Gem Magnolia",
+      "scientific": "Magnolia grandiflora 'Little Gem'",
+      "genus": "Magnolia grandiflora 'Little Gem'"
+    },
+    {
+      "common": "Little-Leaf Azara",
+      "scientific": "Azara microphylla",
+      "genus": "Azara "
+    },
+    {
+      "common": "Little-Leaf Azara",
+      "scientific": "Azara microphylla",
+      "genus": "Azara microphylla"
+    },
+    {
+      "common": "Littleleaf Linden",
+      "scientific": "Tilia cordata",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Littleleaf Linden",
+      "scientific": "Tilia cordata",
+      "genus": "Tilia cordata"
+    },
+    {
+      "common": "LITTLE LEAF LINDEN",
+      "scientific": "Tilia cordata",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Locust",
+      "scientific": "Robinia x ambigua",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Locust",
+      "scientific": "Robinia x ambigua",
+      "genus": "Robinia x ambigua"
+    },
+    {
+      "common": "LOCUST",
+      "scientific": "Robinia spp.",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Locust, Black",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Locust, Black",
+      "scientific": "Robinia x ambigua 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Locust, Pink-Flowering",
+      "scientific": "Robinia x ambigua",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Lombardy Poplar",
+      "scientific": "Populus nigra 'Italica'",
+      "genus": "Populus "
+    },
+    {
+      "common": "Lombardy Poplar",
+      "scientific": "Populus nigra 'Italica'",
+      "genus": "Populus nigra 'Italica'"
+    },
+    {
+      "common": "LOMBARDY POPLAR",
+      "scientific": "Populus nigra Italica",
+      "genus": "Populus "
+    },
+    {
+      "common": "London plane",
+      "scientific": "Platanus acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "London plane",
+      "scientific": "Platanus x acerifolia 'Columbia' (London Plane)",
+      "genus": "Platanus "
+    },
+    {
+      "common": "LONDON PLANE",
+      "scientific": "Platanus X hispanica",
+      "genus": "Platanus "
+    },
+    {
+      "common": "London Plane Columbia",
+      "scientific": "Platanus hybrida",
+      "genus": "Platanus "
+    },
+    {
+      "common": "London plane tree",
+      "scientific": "Platanus hybrida",
+      "genus": "Platanus "
+    },
+    {
+      "common": "London plane tree",
+      "scientific": "Platanus x acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Long-Leafed Yellow-Wood",
+      "scientific": "Podocarpus henkelii",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "Long-Leafed Yellow-Wood",
+      "scientific": "Podocarpus henkelii",
+      "genus": "Podocarpus henkelii"
+    },
+    {
+      "common": "Loquat",
+      "scientific": "Eriobotrya japonica",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "Loquat, Bronze",
+      "scientific": "Eriobotrya deflexa",
+      "genus": "Eriobotrya "
+    },
+    {
+      "common": "'Louis Edmunds' manzanita",
+      "scientific": "Arctostaphylos stanfordiana bakeri",
+      "genus": "Arctostaphylos"
+    },
+    {
+      "common": "Macadamia",
+      "scientific": "Macadamia tetraphylla",
+      "genus": "Macadamia "
+    },
+    {
+      "common": "Macadamia Nut Tree",
+      "scientific": "Macadamia ternifolia",
+      "genus": "Macadamia "
+    },
+    {
+      "common": "Madrone, Pacific",
+      "scientific": "Arbutus menziesii",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Magnolia",
+      "scientific": "Magnolia",
+      "genus": ""
+    },
+    {
+      "common": "Magnolia",
+      "scientific": "Magnolia species",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia",
+      "scientific": "Magnolia spp",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia",
+      "scientific": "Magnolia spp",
+      "genus": "Magnolia spp"
+    },
+    {
+      "common": "MAGNOLIA",
+      "scientific": "Magnolia stellata",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Bigleaf",
+      "scientific": "Magnolia macrophylla",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Chinese; Saucer",
+      "scientific": "Magnolia x soulangiana",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia grandiflora",
+      "scientific": "Magnolia",
+      "genus": ""
+    },
+    {
+      "common": "Magnolia grandiflora",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia grandiflora 'St Mary'",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia grandiflora 'St. Mary'",
+      "scientific": "Magnolia grandiflora 'St. Mary'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Kobus",
+      "scientific": "Magnolia kobus",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia Little Gem",
+      "scientific": "Magnolia",
+      "genus": ""
+    },
+    {
+      "common": "Magnolia, Little Gem",
+      "scientific": "Magnolia grandiflora-little gem",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Southern",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Southern",
+      "scientific": "Magnolia grandiflora 'St Mary' or 'Samuel Sommer'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Star",
+      "scientific": "Magnolia stellata",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Magnolia, Umbrella",
+      "scientific": "Magnolia tripetala",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Mahagony, Swamp",
+      "scientific": "Eucalyptus robusta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Mahogany, Mountain",
+      "scientific": "Cercocarpus betuloides",
+      "genus": "Cercocarpus "
+    },
+    {
+      "common": "Mahonia, Leatherleaf",
+      "scientific": "Berberis bealei",
+      "genus": "Berberis "
+    },
+    {
+      "common": "Maidenhair Tree",
+      "scientific": "Ginkgo biloba",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Maidenhair Tree",
+      "scientific": "Ginkgo biloba",
+      "genus": "Ginkgo biloba"
+    },
+    {
+      "common": "MAIDENHAIR TREE",
+      "scientific": "Ginkgo biloba",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Majestic Beauty Fruitless Olive",
+      "scientific": "Olea europaea 'Majestic Beauty'",
+      "genus": "Olea "
+    },
+    {
+      "common": "Majestic Beauty Fruitless Olive",
+      "scientific": "Olea europaea 'Majestic Beauty'",
+      "genus": "Olea europaea 'Majestic Beauty'"
+    },
+    {
+      "common": "Majestic Beauty Magnolia",
+      "scientific": "Magnolia grandiflora 'Majestic Beauty'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Majestic Beauty Magnolia",
+      "scientific": "Magnolia grandiflora 'Majestic Beauty'",
+      "genus": "Magnolia grandiflora 'Majestic Beauty'"
+    },
+    {
+      "common": "MALUS SPECIES",
+      "scientific": "Malus spp. & cv.",
+      "genus": "Malus "
+    },
+    {
+      "common": "Manchurian snakebark maple",
+      "scientific": "Acer tegmentosum",
+      "genus": "Acer tegmentosum"
+    },
+    {
+      "common": "Mango",
+      "scientific": "Magnifera indica",
+      "genus": "Magnifera "
+    },
+    {
+      "common": "Mango",
+      "scientific": "Mangifera indica",
+      "genus": "Mangifera "
+    },
+    {
+      "common": "MANGO",
+      "scientific": "Mangifera indica",
+      "genus": "Mangifera "
+    },
+    {
+      "common": "Manna Gum",
+      "scientific": "Eucalyptus viminalis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Manna Gum",
+      "scientific": "Eucalyptus viminalis",
+      "genus": "Eucalyptus viminalis"
+    },
+    {
+      "common": "Manuka",
+      "scientific": "Leptospermum scoparium",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Manzanita",
+      "scientific": "Arctostaphylos species",
+      "genus": "Arctostaphylos "
+    },
+    {
+      "common": "Manzanita, Big Berry",
+      "scientific": "Arctostaphylos glauca",
+      "genus": "Arctostaphylos "
+    },
+    {
+      "common": "Manzanita Dr. Hurd ",
+      "scientific": "Arctostaphylos Manzanita Dr. Hurd ",
+      "genus": "Arctostaphylos"
+    },
+    {
+      "common": "Maple",
+      "scientific": "Acer species",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple",
+      "scientific": "Acer spp",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple",
+      "scientific": "Acer spp",
+      "genus": "Acer spp"
+    },
+    {
+      "common": "MAPLE",
+      "scientific": "Acer spp.",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Amur",
+      "scientific": "Acer ginnala",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Bigleaf",
+      "scientific": "Acer macrophyllum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Black",
+      "scientific": "Acer nigrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Freeman",
+      "scientific": "Acer x freemanii",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Fullmoon",
+      "scientific": "Acer shirasawanum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Hedge",
+      "scientific": "Acer campestre",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Japanese",
+      "scientific": "Acer palmatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Lace-leaf",
+      "scientific": "Acer palmatum 'Dissectum'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Norway",
+      "scientific": "Acer platanoides",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Norway 'Crimson King'",
+      "scientific": "Acer platanoides 'Crimson King'",
+      "genus": "Acer "
+    },
+    {
+      "common": "MAPLE OCTOBER GLORY",
+      "scientific": "Acer rubrum October Glory",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Pacific Sunset",
+      "scientific": "Acer platanoides 'Pacific Sunset'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Paperbark",
+      "scientific": "Acer griseum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Red",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Red",
+      "scientific": "Acer x freemanii 'Jeffersred' (Autumn Blaze maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Red 'October Glory'",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Scarlet",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Shantung",
+      "scientific": "Acer truncatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Silver",
+      "scientific": "Acer saccharinum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Sugar",
+      "scientific": "Acer saccharum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Sycamore",
+      "scientific": "Acer pseudoplatanus",
+      "genus": "Acer "
+    },
+    {
+      "common": "MAPLE SYCAMORE",
+      "scientific": "Acer pseudoplatanus",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Tatar",
+      "scientific": "Acer tataricum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Maple, Trident",
+      "scientific": "Acer buergerianum",
+      "genus": "Acer "
+    },
+    {
+      "common": "MAPLE TRUNCATUM",
+      "scientific": "Acer truncatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "MARINA ARBUTUS",
+      "scientific": "Arbutus Marina",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "MARINA MADRONE",
+      "scientific": "Arbutus menzesii",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Marina tree",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Mariposa Plum",
+      "scientific": "Prunus domestica 'Mariposa'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Mariposa Plum",
+      "scientific": "Prunus domestica 'Mariposa'",
+      "genus": "Prunus domestica 'Mariposa'"
+    },
+    {
+      "common": "Maritime Pine",
+      "scientific": "Pinus pinaster",
+      "genus": "Pinus pinaster"
+    },
+    {
+      "common": "Mayten",
+      "scientific": "Maytenus boaria",
+      "genus": "Maytenus "
+    },
+    {
+      "common": "Mayten",
+      "scientific": "Maytenus boaria",
+      "genus": "Maytenus boaria"
+    },
+    {
+      "common": "MAYTEN TREE",
+      "scientific": "Maytenus boaria",
+      "genus": "Maytenus "
+    },
+    {
+      "common": "Mediterranean Fan Palm",
+      "scientific": "Chamaerops humilis",
+      "genus": "Chamaerops "
+    },
+    {
+      "common": "Mediterranean Fan Palm",
+      "scientific": "Chamaerops humilis",
+      "genus": "Chamaerops humilis"
+    },
+    {
+      "common": "MELALEUCA",
+      "scientific": "Melaleuca spp.",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Melaleuca spp",
+      "scientific": "Melaleuca spp",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Melaleuca spp",
+      "scientific": "Melaleuca spp",
+      "genus": "Melaleuca spp"
+    },
+    {
+      "common": "Mesquite",
+      "scientific": "Prosopis species",
+      "genus": "Prosopis "
+    },
+    {
+      "common": "Mesquite, Honey",
+      "scientific": "Prosopis glandulosa",
+      "genus": "Prosopis "
+    },
+    {
+      "common": "Metrosideros excelsa 'Aurea'",
+      "scientific": "Metrosideros excelsa 'Aurea'",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "Metrosideros excelsa 'Aurea'",
+      "scientific": "Metrosideros excelsa 'Aurea'",
+      "genus": "Metrosideros excelsa 'Aurea'"
+    },
+    {
+      "common": "Metrosideros spp",
+      "scientific": "Metrosideros spp",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "Metrosideros spp",
+      "scientific": "Metrosideros spp",
+      "genus": "Metrosideros spp"
+    },
+    {
+      "common": "Mexican Blue Palm",
+      "scientific": "Brahea aramata",
+      "genus": "Brahea "
+    },
+    {
+      "common": "Mexican Fan Palm",
+      "scientific": "Washingtonia robusta",
+      "genus": "Washingtonia "
+    },
+    {
+      "common": "Mexican Fan Palm",
+      "scientific": "Washingtonia robusta",
+      "genus": "Washingtonia robusta"
+    },
+    {
+      "common": "MEXICAN FAN PALM",
+      "scientific": "Washingtonia robusta",
+      "genus": "Washingtonia "
+    },
+    {
+      "common": "Michelia, Sweet",
+      "scientific": "Michelia doltsopa",
+      "genus": "Michelia "
+    },
+    {
+      "common": "Milkwort, Myrtle-Leaf",
+      "scientific": "Polygala myrtifolia",
+      "genus": "Polygala "
+    },
+    {
+      "common": "mimosa",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia "
+    },
+    {
+      "common": "mimosa",
+      "scientific": "Albizia julibrissin - silk tree",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Mimosa",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Mimosa Silk Tree",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Mimosa Silk Tree",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia julibrissin"
+    },
+    {
+      "common": "Mioporo",
+      "scientific": "Myoporum laetum",
+      "genus": "Myoporum "
+    },
+    {
+      "common": "Mirrorplant, Creeping",
+      "scientific": "Coprosma repens",
+      "genus": "Coprosma "
+    },
+    {
+      "common": "MOCK ORANGE",
+      "scientific": "Pittosporum tobira",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Mock orange, sweet",
+      "scientific": "Philladelphus coronarius",
+      "genus": "Philladelphus "
+    },
+    {
+      "common": "Modesto Ash",
+      "scientific": "Fraxinus velutina",
+      "genus": "Fraxinus velutina"
+    },
+    {
+      "common": "MODESTO ASH",
+      "scientific": "Fraxinus velutina Modesto",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Modesto Ash Tree 'Modesto'",
+      "scientific": "Fraxinus velutina 'Modesto'",
+      "genus": "Fraxinus velutina 'Modesto'"
+    },
+    {
+      "common": "Monkey Hand Tree",
+      "scientific": "Chiranthodendron pentadactylon",
+      "genus": "Chiranthodendron "
+    },
+    {
+      "common": "Monkey Hand Tree",
+      "scientific": "Chiranthodendron pentadactylon",
+      "genus": "Chiranthodendron pentadactylon"
+    },
+    {
+      "common": "Monkey puzzle",
+      "scientific": "Araucaria araucana",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Monkey puzzle",
+      "scientific": "Araucaria araucana",
+      "genus": "Araucaria araucana"
+    },
+    {
+      "common": "MONKEY PUZZLE",
+      "scientific": "Araucaria araucana",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Monkeypuzzle Tree",
+      "scientific": "Araucaria araucana",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Monterey Cypress",
+      "scientific": "Cupressus macrocarpa",
+      "genus": "Cupressus "
+    },
+    {
+      "common": "Monterey Cypress",
+      "scientific": "Cupressus macrocarpa",
+      "genus": "Cupressus macrocarpa"
+    },
+    {
+      "common": "MONTEREY CYPRESS",
+      "scientific": "Hesperocyparis macrocarpa",
+      "genus": "Hesperocyparis "
+    },
+    {
+      "common": "Monterey Pine",
+      "scientific": "Pinus radiata",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Monterey Pine",
+      "scientific": "Pinus radiata",
+      "genus": "Pinus radiata"
+    },
+    {
+      "common": "MONTEREY PINE",
+      "scientific": "Pinus radiata",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Montezuma Cypress",
+      "scientific": "Taxodium mucronatum",
+      "genus": "Taxodium "
+    },
+    {
+      "common": "Montezuma Cypress",
+      "scientific": "Taxodium mucronatum",
+      "genus": "Taxodium mucronatum"
+    },
+    {
+      "common": "Moraine Ash",
+      "scientific": "Fraxinus x Moraine",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Moraine Ash",
+      "scientific": "Fraxinus x Moraine",
+      "genus": "Fraxinus x Moraine"
+    },
+    {
+      "common": "MORAINE ASH",
+      "scientific": "Fraxinus holotricha Moraine",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "MORETON BAY FIG",
+      "scientific": "Ficus macrophylla",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Morton Bay Fig",
+      "scientific": "Ficus macrophylla",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Morton Bay Fig",
+      "scientific": "Ficus macrophylla",
+      "genus": "Ficus macrophylla"
+    },
+    {
+      "common": "Mountain-ash",
+      "scientific": "Sorbus species",
+      "genus": "Sorbus "
+    },
+    {
+      "common": "Mountain-ash, European",
+      "scientific": "Sorbus aucuparia",
+      "genus": "Sorbus "
+    },
+    {
+      "common": "Mountain mahogany",
+      "scientific": "Cercocarpus betuloides",
+      "genus": "Cercocarpus betuloides"
+    },
+    {
+      "common": "Mt. Fuji Cherry Tree",
+      "scientific": "Prunus serrulata 'Mt. Fuji'",
+      "genus": "Prunus serrulata 'Mt. Fuji'"
+    },
+    {
+      "common": "Mulberry",
+      "scientific": "Morus species",
+      "genus": "Morus "
+    },
+    {
+      "common": "Mulberry, Black",
+      "scientific": "Morus nigra",
+      "genus": "Morus "
+    },
+    {
+      "common": "MULBERRY SPECIES",
+      "scientific": "Morus spp.",
+      "genus": "Morus "
+    },
+    {
+      "common": "Mulberry, White",
+      "scientific": "Morus alba",
+      "genus": "Morus "
+    },
+    {
+      "common": "MUSKOGEE CRAPE MYRTLE",
+      "scientific": "Lagerstroemia indica Muskogee",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Myola palm",
+      "scientific": "Archontophoenix myolensis",
+      "genus": "Archontophoenix "
+    },
+    {
+      "common": "Myola palm",
+      "scientific": "Archontophoenix myolensis",
+      "genus": "Archontophoenix myolensis"
+    },
+    {
+      "common": "Myoporum",
+      "scientific": "Myoporum laetum",
+      "genus": "Myoporum "
+    },
+    {
+      "common": "Myoporum",
+      "scientific": "Myoporum laetum",
+      "genus": "Myoporum laetum"
+    },
+    {
+      "common": "MYOPORUM",
+      "scientific": "Myoporum laetum",
+      "genus": "Myoporum "
+    },
+    {
+      "common": "Myrtle",
+      "scientific": "Myrtus communis",
+      "genus": "Myrtus "
+    },
+    {
+      "common": "Narrow-leaf bottle tree",
+      "scientific": "Brachychiton rupestris",
+      "genus": "Brachychiton "
+    },
+    {
+      "common": "Narrow-leaf bottle tree",
+      "scientific": "Brachychiton rupestris",
+      "genus": "Brachychiton rupestris"
+    },
+    {
+      "common": "Narrow-leaved Ash",
+      "scientific": "Fraxinus angustifolia",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Narrow-leaved Ash",
+      "scientific": "Fraxinus angustifolia",
+      "genus": "Fraxinus angustifolia"
+    },
+    {
+      "common": "Natchez Crape Myrtle",
+      "scientific": "Lagerstroemia indica 'Natchez'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Natchez Crape Myrtle",
+      "scientific": "Lagerstroemia indica 'Natchez'",
+      "genus": "Lagerstroemia indica 'Natchez'"
+    },
+    {
+      "common": "NATCHEZ CRAPE MYRTLE",
+      "scientific": "Lagerstroemia indica Natchez",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Negro, Roble",
+      "scientific": "Quercus ilex",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Neolitsea",
+      "scientific": "Neolitsea sericea",
+      "genus": "Neolitsea "
+    },
+    {
+      "common": "NEW BRADFORD FLOWERING PEAR",
+      "scientific": "Pyrus calleryana New Bradford",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "New Bradford Pear",
+      "scientific": "Pyrus calleryana 'New Bradford'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "New Bradford Pear",
+      "scientific": "Pyrus calleryana 'New Bradford'",
+      "genus": "Pyrus calleryana 'New Bradford'"
+    },
+    {
+      "common": "New Harmony American elm",
+      "scientific": "Ulmus americana 'New Harmony'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "NEW HARMONY ELM",
+      "scientific": "Ulmus americana New Harmony",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "New Planting  )",
+      "scientific": "Sapling",
+      "genus": ""
+    },
+    {
+      "common": "New Zealand Christmas tree",
+      "scientific": "Metrosideros excelsa",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "New Zealand Christmas tree",
+      "scientific": "Metrosideros excelsa (New Zealand Christmas tree)",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "New Zealand Christmas Tree",
+      "scientific": "Metrosideros excelsa",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "NEW ZEALAND CHRISTMAS TREE",
+      "scientific": "Metrosideros excelsus",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "New Zealand Laurel",
+      "scientific": "Corynocarpus laevigata",
+      "genus": "Corynocarpus "
+    },
+    {
+      "common": "New Zealand Laurel",
+      "scientific": "Corynocarpus laevigata",
+      "genus": "Corynocarpus laevigata"
+    },
+    {
+      "common": "New Zealand Ruby Glow Tea Tree",
+      "scientific": "Leptospermum scoparium 'Ruby Glow'",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "New Zealand Ruby Glow Tea Tree",
+      "scientific": "Leptospermum scoparium 'Ruby Glow'",
+      "genus": "Leptospermum scoparium 'Ruby Glow'"
+    },
+    {
+      "common": "New Zealand Tea Tree",
+      "scientific": "Leptospermum scoparium",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "New Zealand Tea Tree",
+      "scientific": "Leptospermum scoparium",
+      "genus": "Leptospermum scoparium"
+    },
+    {
+      "common": "New Zealand Tea Tree",
+      "scientific": "New Zealand Tea Tree",
+      "genus": "New "
+    },
+    {
+      "common": "New Zealand Tea Tree",
+      "scientific": "New Zealand Tea Tree",
+      "genus": "New Zealand Tea Tree"
+    },
+    {
+      "common": "New Zealand White Tea Tree",
+      "scientific": "Leptospermum scoparium 'Snow White'",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "New Zealand White Tea Tree",
+      "scientific": "Leptospermum scoparium 'Snow White'",
+      "genus": "Leptospermum scoparium 'Snow White'"
+    },
+    {
+      "common": "New Zealand Xmas Tree",
+      "scientific": "Metrosideros excelsa",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "New Zealand Xmas Tree",
+      "scientific": "Metrosideros excelsa",
+      "genus": "Metrosideros excelsa"
+    },
+    {
+      "common": "Nichol's Willow-Leafed Peppermint",
+      "scientific": "Eucalyptus nicholii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Nichol's Willow-Leafed Peppermint",
+      "scientific": "Eucalyptus nicholii",
+      "genus": "Eucalyptus nicholii"
+    },
+    {
+      "common": "NICHOLS WILLOW LEAFED PEPPERMINT",
+      "scientific": "Eucalyptus nicholii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Nikau palm",
+      "scientific": "Rhopalostylis sapida",
+      "genus": "Rhopalostylis "
+    },
+    {
+      "common": "NorCal black walnut",
+      "scientific": "Juglans hindsii",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Norfolk Island Pine",
+      "scientific": "Araucaria heterophylla",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Norfolk Island Pine",
+      "scientific": "Araucaria heterophylla",
+      "genus": "Araucaria heterophylla"
+    },
+    {
+      "common": "NORFOLK ISLAND PINE",
+      "scientific": "Araucaria heterophylla",
+      "genus": "Araucaria "
+    },
+    {
+      "common": "Northern Catalpa",
+      "scientific": "Catalpa speciosa",
+      "genus": "Catalpa "
+    },
+    {
+      "common": "northern pin oak",
+      "scientific": "Quercus ellipsoidalis",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Northern Rata Tree",
+      "scientific": "Metrosideros robusta",
+      "genus": "Metrosideros "
+    },
+    {
+      "common": "Northern Red Oak",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus"
+    },
+    {
+      "common": "Norway maple",
+      "scientific": "Acer platanoides 'Crimson King'",
+      "genus": "Acer platanoides 'Crimson King'"
+    },
+    {
+      "common": "Norway Maple",
+      "scientific": "Acer platanoides",
+      "genus": "Acer platanoides"
+    },
+    {
+      "common": "Nuttall oak",
+      "scientific": "Quercus Nuttallii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak",
+      "scientific": "Quercus species",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak",
+      "scientific": "Quercus spp",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak",
+      "scientific": "Quercus spp",
+      "genus": "Quercus spp"
+    },
+    {
+      "common": "Oak, Black",
+      "scientific": "Quercus velutina",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Blue",
+      "scientific": "Quercus douglasii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Bur",
+      "scientific": "Quercus macrocarpa",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, California Black",
+      "scientific": "Quercus kelloggii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, California White",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Canyon Live",
+      "scientific": "Quercus chrysolepis",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Chinkapin",
+      "scientific": "Quercus muehlenbergii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Coastal/California Live",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Cork",
+      "scientific": "Quercus suber",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, English",
+      "scientific": "Quercus robur",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Hybrid",
+      "scientific": "Quercus x",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Interior Live",
+      "scientific": "Quercus wislizeni",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Live",
+      "scientific": "Quercus virginiana",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Northern Pin",
+      "scientific": "Quercus ellipsoidalis",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Northern Red",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Northern Red",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Pin",
+      "scientific": "Quercus palustris",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Post",
+      "scientific": "Quercus stellata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Sawtooth",
+      "scientific": "Quercus acutissima",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Scarlet",
+      "scientific": "Quercus coccinea",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Shingle",
+      "scientific": "Quercus imbricaria",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Shumard",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Southern Red",
+      "scientific": "Quercus falcata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Swamp White",
+      "scientific": "Quercus bicolor",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, White",
+      "scientific": "Quercus alba",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Oak, Willow",
+      "scientific": "Quercus phellos",
+      "genus": "Quercus "
+    },
+    {
+      "common": "October Glory",
+      "scientific": "Acer Rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "October Glory red maple",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "October Glory red maple",
+      "scientific": "Acer rubrum 'October Glory' (red maple)",
+      "genus": "Acer "
+    },
+    {
+      "common": "October Glory Red Maple",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Octopus Tree",
+      "scientific": "Schefflera actinophylla",
+      "genus": "Schefflera "
+    },
+    {
+      "common": "Olea Majestic Beauty",
+      "scientific": "Olea Majestic Beauty",
+      "genus": "Olea "
+    },
+    {
+      "common": "Olea Majestic Beauty",
+      "scientific": "Olea Majestic Beauty",
+      "genus": "Olea Majestic Beauty"
+    },
+    {
+      "common": "Oleander",
+      "scientific": "Nerium oleander",
+      "genus": "Nerium "
+    },
+    {
+      "common": "Oleander",
+      "scientific": "Nerium oleander",
+      "genus": "Nerium oleander"
+    },
+    {
+      "common": "OLEANDER",
+      "scientific": "Nerium oleander",
+      "genus": "Nerium "
+    },
+    {
+      "common": "Olive",
+      "scientific": "Olea europaea",
+      "genus": "Olea "
+    },
+    {
+      "common": "Olive",
+      "scientific": "Olea europaea 'Swan Hill'",
+      "genus": "Olea "
+    },
+    {
+      "common": "Olive",
+      "scientific": "Olea europaea 'Swan Hill'",
+      "genus": "Olea europaea 'Swan Hill'"
+    },
+    {
+      "common": "OLIVE",
+      "scientific": "Olea europaea",
+      "genus": "Olea "
+    },
+    {
+      "common": "Olive, Autumn",
+      "scientific": "Elaeagnus umbellata",
+      "genus": "Elaeagnus "
+    },
+    {
+      "common": "Olive, Russian",
+      "scientific": "Elaeagnus angustifolia",
+      "genus": "Elaeagnus "
+    },
+    {
+      "common": "Olive Tree",
+      "scientific": "Olea europaea",
+      "genus": "Olea "
+    },
+    {
+      "common": "Olive Tree",
+      "scientific": "Olea europaea",
+      "genus": "Olea europaea"
+    },
+    {
+      "common": "Olor, Laurel de",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus "
+    },
+    {
+      "common": "O'Neill Red Horse Chestnut",
+      "scientific": "Aesculus x carnea 'O'Neill'",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "ORANGE",
+      "scientific": "Citrus sinensis",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Orange, Kona",
+      "scientific": "Citrus sinensis",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Orchid Tree, 'Purpurea'",
+      "scientific": "Bauhinia purpurea",
+      "genus": "Bauhinia "
+    },
+    {
+      "common": "Orchid Tree, Red",
+      "scientific": "Bauhinia galpinii",
+      "genus": "Bauhinia "
+    },
+    {
+      "common": "Orchid Tree, Variegated",
+      "scientific": "Bauhinia variegata",
+      "genus": "Bauhinia "
+    },
+    {
+      "common": "Oriental Sweet Gum",
+      "scientific": "Liquidambar orientalis",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "Oriental Sweet Gum",
+      "scientific": "Liquidambar orientalis",
+      "genus": "Liquidambar orientalis"
+    },
+    {
+      "common": "Ornamental Cherry",
+      "scientific": "Prunus serrulata",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Ornamental Cherry",
+      "scientific": "Prunus serrulata",
+      "genus": "Prunus serrulata"
+    },
+    {
+      "common": "Ornamental Pear",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus calleryana"
+    },
+    {
+      "common": "ORNAMENTAL PEAR",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear: Bradford",
+      "scientific": "Pyrus calleryana 'Bradford'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear: Bradford",
+      "scientific": "Pyrus calleryana 'Bradford'",
+      "genus": "Pyrus calleryana 'Bradford'"
+    },
+    {
+      "common": "Ornamental Pear Tree 'Capital'",
+      "scientific": "Pyrus calleryana 'Capital'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear Tree 'Capital'",
+      "scientific": "Pyrus calleryana 'Capital'",
+      "genus": "Pyrus calleryana 'Capital'"
+    },
+    {
+      "common": "Ornamental Pear Tree 'Chanticleer'",
+      "scientific": "Pyrus calleryana 'Chanticleer'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear Tree 'Chanticleer'",
+      "scientific": "Pyrus calleryana 'Chanticleer'",
+      "genus": "Pyrus calleryana 'Chanticleer'"
+    },
+    {
+      "common": "Ornamental Pear Tree 'Cleveland'",
+      "scientific": "Pyrus calleryana 'Cleveland'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear Tree 'Cleveland'",
+      "scientific": "Pyrus calleryana 'Cleveland'",
+      "genus": "Pyrus calleryana 'Cleveland'"
+    },
+    {
+      "common": "Ornamental Pear Tree 'Redspire'",
+      "scientific": "Pyrus calleryana 'Redspire'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Ornamental Pear Tree 'Redspire'",
+      "scientific": "Pyrus calleryana 'Redspire'",
+      "genus": "Pyrus calleryana 'Redspire'"
+    },
+    {
+      "common": "Osage Orange",
+      "scientific": "Maclura pomifera",
+      "genus": "Maclura "
+    },
+    {
+      "common": "OTHER TREE",
+      "scientific": "Other tree",
+      "genus": "Other "
+    },
+    {
+      "common": "Pacific Madrone",
+      "scientific": "Arbutus menziesii",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Pacific Wax Myrtle Tree",
+      "scientific": "Myrica californica",
+      "genus": "Myrica "
+    },
+    {
+      "common": "Pagodatree, Japanese",
+      "scientific": "Styphnolobium japonicum",
+      "genus": "Styphnolobium "
+    },
+    {
+      "common": "Palm",
+      "scientific": "Palm species",
+      "genus": "Palm "
+    },
+    {
+      "common": "Palm",
+      "scientific": "Rhopalostylis baueri",
+      "genus": "Rhopalostylis "
+    },
+    {
+      "common": "Palm",
+      "scientific": "Rhopalostylis baueri",
+      "genus": "Rhopalostylis baueri"
+    },
+    {
+      "common": "Palm, Australian Fan",
+      "scientific": "Livistona australis",
+      "genus": "Livistona "
+    },
+    {
+      "common": "Palm, Bangalow",
+      "scientific": "Archontophoenix cunninghamiana",
+      "genus": "Archontophoenix "
+    },
+    {
+      "common": "Palm, Bottle",
+      "scientific": "Hyophorbe lagenicaulis",
+      "genus": "Hyophorbe "
+    },
+    {
+      "common": "Palm, California",
+      "scientific": "Washingtonia filifera",
+      "genus": "Washingtonia "
+    },
+    {
+      "common": "Palm, Canary Island Date",
+      "scientific": "Phoenix canariensis",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Palm, Chinese fan",
+      "scientific": "Livistona chinensis",
+      "genus": "Livistona "
+    },
+    {
+      "common": "Palm, Cliff Date",
+      "scientific": "Phoenix rupicola",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Palm, Cuban Royal",
+      "scientific": "Roystonea regia",
+      "genus": "Roystonea "
+    },
+    {
+      "common": "Palm, Date",
+      "scientific": "Phoenix dactylifera",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Palm, Dreadlock",
+      "scientific": "Burretiokentia hapala",
+      "genus": "Burretiokentia "
+    },
+    {
+      "common": "Palm, Dwarf Date",
+      "scientific": "Phoenix roebelenii",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Palmetto, Cabbage",
+      "scientific": "Sabal palmetto",
+      "genus": "Sabal "
+    },
+    {
+      "common": "Palm, European Fan",
+      "scientific": "Chamaerops humilis",
+      "genus": "Chamaerops "
+    },
+    {
+      "common": "Palm, Guadalupe",
+      "scientific": "Brahea edulis",
+      "genus": "Brahea "
+    },
+    {
+      "common": "Palm, Jelly",
+      "scientific": "Butia capitata",
+      "genus": "Butia "
+    },
+    {
+      "common": "Palm, King",
+      "scientific": "Archontophoenix maxima",
+      "genus": "Archontophoenix "
+    },
+    {
+      "common": "Palm, Mexican Blue",
+      "scientific": "Brahea armata",
+      "genus": "Brahea "
+    },
+    {
+      "common": "Palm, Mountain Fishtail",
+      "scientific": "Caryota gigas",
+      "genus": "Caryota "
+    },
+    {
+      "common": "Palm, Nikau",
+      "scientific": "Rhopalostylis sapida",
+      "genus": "Rhopalostylis "
+    },
+    {
+      "common": "Palm, Queen",
+      "scientific": "Arecastrum romanzoffianum",
+      "genus": "Arecastrum "
+    },
+    {
+      "common": "Palm, Ribbon",
+      "scientific": "Livistona decipiens",
+      "genus": "Livistona "
+    },
+    {
+      "common": "Palm, Sago",
+      "scientific": "Cycas revoluta",
+      "genus": "Cycas "
+    },
+    {
+      "common": "Palm, Senegal Date",
+      "scientific": "Phoenix reclinata",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Palm Spp",
+      "scientific": "Palm (unknown Genus)",
+      "genus": "Palm "
+    },
+    {
+      "common": "Palm Spp",
+      "scientific": "Palm (unknown Genus)",
+      "genus": "Palm (unknown Genus)"
+    },
+    {
+      "common": "Palm, Texas",
+      "scientific": "Sabal mexicana",
+      "genus": "Sabal "
+    },
+    {
+      "common": "Palm, Traveller's",
+      "scientific": "Ravenala madagascariensis",
+      "genus": "Ravenala "
+    },
+    {
+      "common": "Palm, Windmill",
+      "scientific": "Trachycarpus fortunei",
+      "genus": "Trachycarpus "
+    },
+    {
+      "common": "Palo Alto Sweet Gum",
+      "scientific": "Liquidambar styraciflua 'Palo Alto'",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "Palo Alto Sweet Gum",
+      "scientific": "Liquidambar styraciflua 'Palo Alto'",
+      "genus": "Liquidambar styraciflua 'Palo Alto'"
+    },
+    {
+      "common": "Paloverde, Blue",
+      "scientific": "Parkinsonia florida",
+      "genus": "Parkinsonia "
+    },
+    {
+      "common": "Paperbark",
+      "scientific": "Melaleuca quinquenervia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Paperbark, Prickly",
+      "scientific": "Melaleuca styphelioides",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Paperbark Tree",
+      "scientific": "Melaleuca styphelliodes",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Paperbark Tree",
+      "scientific": "Melaleuca styphelliodes",
+      "genus": "Melaleuca styphelliodes"
+    },
+    {
+      "common": "Paradox Walnut Tree 'Paradox'",
+      "scientific": "Juglans 'Paradox'",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Parkinsonia",
+      "scientific": "Cercidium praecox",
+      "genus": "Cercidium "
+    },
+    {
+      "common": "Parrotia persica",
+      "scientific": "Hamamelis virginiana",
+      "genus": "Hamamelis "
+    },
+    {
+      "common": "Paulownia, Royal",
+      "scientific": "Paulownia tomentosa",
+      "genus": "Paulownia "
+    },
+    {
+      "common": "Paul's Scarlet Hawthorn",
+      "scientific": "Crataegus laevigata 'Paul's Scarlet'",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Paul's Scarlet Hawthorn",
+      "scientific": "Crataegus laevigata 'Paul's Scarlet'",
+      "genus": "Crataegus laevigata 'Paul's Scarlet'"
+    },
+    {
+      "common": "Peach",
+      "scientific": "Prunus persica",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Peach",
+      "scientific": "Prunus persica",
+      "genus": "Prunus persica"
+    },
+    {
+      "common": "PEACH",
+      "scientific": "Prunus persica",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Pear",
+      "scientific": "Pyrus species",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear, Callery",
+      "scientific": "Pyrus calleryana",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear, Callery 'Aristocrat'",
+      "scientific": "Pyrus calleryana 'Aristocrat'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear, Callery 'Bradford'",
+      "scientific": "Pyrus calleryana 'Bradford'",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear, Common",
+      "scientific": "Pyrus communis",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear, Evergreen",
+      "scientific": "Pyrus kawakamii",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear Tree",
+      "scientific": "Pyrus spp",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "Pear Tree",
+      "scientific": "Pyrus spp",
+      "genus": "Pyrus spp"
+    },
+    {
+      "common": "Pecan",
+      "scientific": "Carya illinoensis",
+      "genus": "Carya "
+    },
+    {
+      "common": "Pecan",
+      "scientific": "Carya illinoinensis",
+      "genus": "Carya "
+    },
+    {
+      "common": "PECAN",
+      "scientific": "Carya illinoinensis",
+      "genus": "Carya "
+    },
+    {
+      "common": "Pencil Tree",
+      "scientific": "Euphorbia tirucalli",
+      "genus": "Euphorbia "
+    },
+    {
+      "common": "Peppermint Box",
+      "scientific": "Eucalyptus odorata",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Peppermint Box",
+      "scientific": "Eucalyptus odorata",
+      "genus": "Eucalyptus odorata"
+    },
+    {
+      "common": "peppermint tree",
+      "scientific": "Agonis flexuosa",
+      "genus": "Agonis "
+    },
+    {
+      "common": "Peppermint Tree",
+      "scientific": "Agonis flexuosa",
+      "genus": "Agonis "
+    },
+    {
+      "common": "Peppermint Willow",
+      "scientific": "Agonis flexuosa",
+      "genus": "Agonis "
+    },
+    {
+      "common": "Peppermint Willow",
+      "scientific": "Agonis flexuosa",
+      "genus": "Agonis flexuosa"
+    },
+    {
+      "common": "Peppermint willow 'After Dark'",
+      "scientific": "Agonis flexuosa 'After Dark'",
+      "genus": "Agonis "
+    },
+    {
+      "common": "Peppermint willow 'After Dark'",
+      "scientific": "Agonis flexuosa 'After Dark'",
+      "genus": "Agonis flexuosa 'After Dark'"
+    },
+    {
+      "common": "Pepper Tree",
+      "scientific": "Schinus molle",
+      "genus": "Schinus "
+    },
+    {
+      "common": "Persian ironwood",
+      "scientific": "Parrotia persica",
+      "genus": "Parrotia "
+    },
+    {
+      "common": "Persian ironwood",
+      "scientific": "Parrotia persica 'Vanessa' (Persian ironwood)",
+      "genus": "Parrotia "
+    },
+    {
+      "common": "PERSIAN IRONWOOD",
+      "scientific": "Parrotia persica",
+      "genus": "Parrotia "
+    },
+    {
+      "common": "Persimmon",
+      "scientific": "Diospyros kaki",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Persimmon",
+      "scientific": "Diospyros kaki",
+      "genus": "Diospyros kaki"
+    },
+    {
+      "common": "Persimmon, Common",
+      "scientific": "Diospyros virginiana",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Persimmon, Japanese",
+      "scientific": "Diospyros kaki",
+      "genus": "Diospyros "
+    },
+    {
+      "common": "Pheasant Wood",
+      "scientific": "Senna siamea",
+      "genus": "Senna "
+    },
+    {
+      "common": "Photinia, Chinese",
+      "scientific": "Photinia serrulata",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Photinia: Chinese photinia",
+      "scientific": "Photinia fraseri",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Photinia: Chinese photinia",
+      "scientific": "Photinia fraseri",
+      "genus": "Photinia fraseri"
+    },
+    {
+      "common": "Photinia, Fraser",
+      "scientific": "Photinia x fraseri",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Photinia fraseri",
+      "scientific": "Fraser photinia",
+      "genus": "Fraser "
+    },
+    {
+      "common": "Photinia Tree",
+      "scientific": "Photinia fraseri",
+      "genus": "Photinia "
+    },
+    {
+      "common": "Photinia Tree",
+      "scientific": "Photinia fraseri",
+      "genus": "Photinia fraseri"
+    },
+    {
+      "common": "Pigmy Date Palm",
+      "scientific": "Phoenix roebelenii",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Pigmy Date Palm",
+      "scientific": "Phoenix roebelenii",
+      "genus": "Phoenix roebelenii"
+    },
+    {
+      "common": "Pincushion, Ornamental",
+      "scientific": "Leucospermum cordifolium",
+      "genus": "Leucospermum "
+    },
+    {
+      "common": "PINCUSHION TREE",
+      "scientific": "Hakea laurina",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Pindo Palm",
+      "scientific": "Butia capitata",
+      "genus": "Butia "
+    },
+    {
+      "common": "Pindo Palm",
+      "scientific": "Butia capitata",
+      "genus": "Butia capitata"
+    },
+    {
+      "common": "Pine",
+      "scientific": "Pinus species",
+      "genus": "Pinus "
+    },
+    {
+      "common": "PINE",
+      "scientific": "Pinus spp.",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Aleppo",
+      "scientific": "Pinus halepensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pineapple Guava",
+      "scientific": "",
+      "genus": ""
+    },
+    {
+      "common": "Pineapple-Guava",
+      "scientific": "Acca sellowiana",
+      "genus": "Acca "
+    },
+    {
+      "common": "Pineapple Guava Tree",
+      "scientific": "Acca sellowiana",
+      "genus": "Acca "
+    },
+    {
+      "common": "Pineapple Guava Tree",
+      "scientific": "Acca sellowiana",
+      "genus": "Acca sellowiana"
+    },
+    {
+      "common": "Pine, Canary Island",
+      "scientific": "Pinus canariensis",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Coulter",
+      "scientific": "Pinus coulteri",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Eastern White",
+      "scientific": "Pinus strobus",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Fern",
+      "scientific": "Platanus x acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Pine, Fern",
+      "scientific": "Podocarpus gracilior",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "Pine, Jack",
+      "scientific": "Pinus banksiana",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Japanese Black",
+      "scientific": "Pinus thunbergiana",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Lodgepole",
+      "scientific": "Pinus contorta",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Monterey",
+      "scientific": "Pinus radiata",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Patula",
+      "scientific": "Pinus patula",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Ponderosa",
+      "scientific": "Pinus ponderosa",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Red",
+      "scientific": "Pinus resinosa",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine Spp",
+      "scientific": "Pinus Spp",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine Spp",
+      "scientific": "Pinus Spp",
+      "genus": "Pinus Spp"
+    },
+    {
+      "common": "Pine, Sweet Mountain",
+      "scientific": "Pinus mugo",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Turkish;East Mediterranean",
+      "scientific": "Pinus brutia",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pine, Umbrella",
+      "scientific": "Pinus pinea",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Pink Melaleuca",
+      "scientific": "Melaleuca nesophila",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Pink Melaleuca",
+      "scientific": "Melaleuca nesophila",
+      "genus": "Melaleuca nesophila"
+    },
+    {
+      "common": "pin oak",
+      "scientific": "Quercus palustris",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Pin Oak",
+      "scientific": "Quercus palustris",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Pin Oak",
+      "scientific": "Quercus palustris",
+      "genus": "Quercus palustris"
+    },
+    {
+      "common": "PIN OAK",
+      "scientific": "Quercus palustris",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Pioneer hybrid elm",
+      "scientific": "Ulmus x 'Pioneer'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Pistache, Chinese",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "Pistachio",
+      "scientific": "Pistacia vera",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "PITTOSPORUM",
+      "scientific": "Pittosporum spp.",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Pittosporum, Japanese",
+      "scientific": "Pittosporum tobira",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Pittosporum, Queensland",
+      "scientific": "Pittosporum rhombifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Pittosporum spp",
+      "scientific": "Pittosporum spp",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Pittosporum spp",
+      "scientific": "Pittosporum spp",
+      "genus": "Pittosporum spp"
+    },
+    {
+      "common": "Pittosporum, Tarata",
+      "scientific": "Pittosporum tenuifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Planetree, Bloodgood",
+      "scientific": "Platanus x hispanica 'Bloodgood'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Planetree, London",
+      "scientific": "Platanus acerifolia 'Columbia' (London plane)",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Planetree, London",
+      "scientific": "Platanus hybrida",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Planetree, London",
+      "scientific": "Platanus x acerifolia 'Columbia'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Planetree, London",
+      "scientific": "Platanus x acerifolia 'Columbia' (London Plane)",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Planetree, Yarwood",
+      "scientific": "Platanus x hispanica 'Yarwood'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Plum",
+      "scientific": "Prunus species",
+      "genus": "Prunus "
+    },
+    {
+      "common": "PLUM",
+      "scientific": "Prunus domestica",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, American",
+      "scientific": "Prunus americana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Blierana",
+      "scientific": "Prunus blieriana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Cherry",
+      "scientific": "Prunus blireana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Cherry",
+      "scientific": "Prunus blireiana Double-Pink-Flowering Plum",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Cherry",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Cherry",
+      "scientific": "Prunus x blireana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Cherry",
+      "scientific": "Prunus x blireiana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Chickasaw",
+      "scientific": "Prunus angustifolia",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plum, Common",
+      "scientific": "Prunus domestica",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Plume Albizia Tree",
+      "scientific": "Albizia distachya",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Plume Albizia Tree",
+      "scientific": "Albizia distachya",
+      "genus": "Albizia distachya"
+    },
+    {
+      "common": "Plum, Thundercloud Purple",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Podocarpus, Yew",
+      "scientific": "Podocarpus macrophyllus",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "POLE",
+      "scientific": "Pole",
+      "genus": ""
+    },
+    {
+      "common": "Pomegranate",
+      "scientific": "Punica granatum",
+      "genus": "Punica "
+    },
+    {
+      "common": "Pomegranate Tree 'Wonderful'",
+      "scientific": "Punica granatum 'Wonderfu",
+      "genus": "Punica "
+    },
+    {
+      "common": "Pomegranate Tree 'Wonderful'",
+      "scientific": "Punica granatum 'Wonderfu",
+      "genus": "Punica granatum 'Wonderfu"
+    },
+    {
+      "common": "Ponytail palm",
+      "scientific": "Beaucarnea recurvata",
+      "genus": "Beaucarnea "
+    },
+    {
+      "common": "Ponytail palm",
+      "scientific": "Beaucarnea recurvata",
+      "genus": "Beaucarnea recurvata"
+    },
+    {
+      "common": "POOR PLANTING SITE",
+      "scientific": "Poor planting site",
+      "genus": "Poor "
+    },
+    {
+      "common": "POPLAR",
+      "scientific": "Populus spp.",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poplar, Balsam",
+      "scientific": "Populus balsamifera",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poplar, Black",
+      "scientific": "Populus nigra",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poplar, Lombardy",
+      "scientific": "Populus nigra 'Italica'",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poplar Spp",
+      "scientific": "Populus spp",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poplar Spp",
+      "scientific": "Populus spp",
+      "genus": "Populus spp"
+    },
+    {
+      "common": "Poplar, White",
+      "scientific": "Populus alba",
+      "genus": "Populus "
+    },
+    {
+      "common": "Poroporo",
+      "scientific": "Solanum aviculare",
+      "genus": "Solanum "
+    },
+    {
+      "common": "Port Jackson Fig",
+      "scientific": "Ficus rubiginosa",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Port Jackson Fig",
+      "scientific": "Ficus rubiginosa",
+      "genus": "Ficus rubiginosa"
+    },
+    {
+      "common": "Port Orford Cedar",
+      "scientific": "Chamaecyparis lawsoniana",
+      "genus": "Chamaecyparis lawsoniana"
+    },
+    {
+      "common": "Portugese Cherry Laurel",
+      "scientific": "Prunus lusitanica",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Portugese Cherry Laurel",
+      "scientific": "Prunus lusitanica",
+      "genus": "Prunus lusitanica"
+    },
+    {
+      "common": "POTATO VINE",
+      "scientific": "Solanum jasminoides",
+      "genus": "Solanum "
+    },
+    {
+      "common": "Pot Belly Fig",
+      "scientific": "Ficus microcarpa 'Retusa'",
+      "genus": "Ficus "
+    },
+    {
+      "common": "Pot Belly Fig",
+      "scientific": "Ficus microcarpa 'Retusa'",
+      "genus": "Ficus microcarpa 'Retusa'"
+    },
+    {
+      "common": "Potential Site",
+      "scientific": "Potential Site",
+      "genus": "Potential "
+    },
+    {
+      "common": "Potential Site",
+      "scientific": "Potential Site",
+      "genus": "Potential Site"
+    },
+    {
+      "common": "PRAIRIEFIRE CRABAPPLE",
+      "scientific": "Malus ioensis Prairiefire",
+      "genus": "Malus "
+    },
+    {
+      "common": "Prairie Fire Crabapple Tree",
+      "scientific": "Malus floribunda 'Prairie Fire'",
+      "genus": "Malus "
+    },
+    {
+      "common": "Pride-of-India",
+      "scientific": "Melia azedarach",
+      "genus": "Melia "
+    },
+    {
+      "common": "Pride of Madiera",
+      "scientific": "Echium candicans",
+      "genus": "Echium "
+    },
+    {
+      "common": "primrose tree",
+      "scientific": "Lagunaria patersonia",
+      "genus": "Lagunaria "
+    },
+    {
+      "common": "primrose tree",
+      "scientific": "Lagunaria patersonii",
+      "genus": "Lagunaria "
+    },
+    {
+      "common": "Primrose Tree",
+      "scientific": "Lagunaria patersonii",
+      "genus": "Lagunaria "
+    },
+    {
+      "common": "Primrose Tree",
+      "scientific": "Lagunaria patersonii",
+      "genus": "Lagunaria patersonii"
+    },
+    {
+      "common": "Princess Flower",
+      "scientific": "Tibochina urvilleana",
+      "genus": "Tibochina "
+    },
+    {
+      "common": "Princess Flower",
+      "scientific": "Tibochina urvilleana",
+      "genus": "Tibochina urvilleana"
+    },
+    {
+      "common": "Princeton American elm",
+      "scientific": "Ulmus americana 'Princeton'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Princeton Elm",
+      "scientific": "",
+      "genus": ""
+    },
+    {
+      "common": "PRINCETON ELM",
+      "scientific": "Ulmus americana Princeton",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Princeton Sentry Maidenhair",
+      "scientific": "Ginkgo biloba 'Princeton Sentry'",
+      "genus": "Ginkgo "
+    },
+    {
+      "common": "Princeton Sentry Maidenhair",
+      "scientific": "Ginkgo biloba 'Princeton Sentry'",
+      "genus": "Ginkgo biloba 'Princeton Sentry'"
+    },
+    {
+      "common": "Private Shrub",
+      "scientific": "Private shrub",
+      "genus": "Private "
+    },
+    {
+      "common": "Private Shrub",
+      "scientific": "Private shrub",
+      "genus": "Private shrub"
+    },
+    {
+      "common": "Privet",
+      "scientific": "Ligustrum species",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Privet",
+      "scientific": "Privet",
+      "genus": ""
+    },
+    {
+      "common": "Privet",
+      "scientific": "Privet",
+      "genus": "Privet"
+    },
+    {
+      "common": "PRIVET",
+      "scientific": "Ligustrum confusum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "PRIVET",
+      "scientific": "Ligustrum spp.",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Privet, California",
+      "scientific": "Ligustrum ovalifolium",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Privet, Glossy",
+      "scientific": "Ligustrum lucidum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Privet, Japanese",
+      "scientific": "Ligustrum japonicum",
+      "genus": "Ligustrum "
+    },
+    {
+      "common": "Prospector Elm",
+      "scientific": "Ulmus 'Prospector'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Prospector Elm",
+      "scientific": "Ulmus 'Prospector'",
+      "genus": "Ulmus 'Prospector'"
+    },
+    {
+      "common": "Prunus cerasifera 'Krauter Vesuvius'",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Prunus x blireana",
+      "scientific": "Prunus blieriana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Prunus x blireana",
+      "scientific": "Prunus x blireana",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Puka or puke tree",
+      "scientific": "Meryta sinclairii",
+      "genus": "Meryta sinclairii"
+    },
+    {
+      "common": "Puriri tree",
+      "scientific": "Vitex lucens",
+      "genus": "Vitex "
+    },
+    {
+      "common": "Puriri tree",
+      "scientific": "Vitex lucens",
+      "genus": "Vitex lucens"
+    },
+    {
+      "common": "Purple bottlebrush",
+      "scientific": "Callistemon 'Jeffers'",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Purple bottlebrush",
+      "scientific": "Callistemon 'Jeffers'",
+      "genus": "Callistemon 'Jeffers'"
+    },
+    {
+      "common": "purple-flowering locust",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia "
+    },
+    {
+      "common": "purple-flowering locust",
+      "scientific": "Robinia 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "purple-flowering locust",
+      "scientific": "Robinia x ambigua 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "purple-flowering locust",
+      "scientific": "Robinia x ambigua ?Purple Robe?",
+      "genus": "Robinia "
+    },
+    {
+      "common": "purple-flowering locust",
+      "scientific": "Robinia x Ambigua 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple-flowering Locust",
+      "scientific": "Robinia x ambigua 'Purple Robe' (Purple Robe locust)",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple Glory Tree",
+      "scientific": "Tibouchina granulosa",
+      "genus": "Tibouchina "
+    },
+    {
+      "common": "Purple Hopseed Bush",
+      "scientific": "Dodonaea viscosa purpurea",
+      "genus": "Dodonaea"
+    },
+    {
+      "common": "Purple Hopseed Bush",
+      "scientific": "Dodonaea viscosa 'Purpurea'",
+      "genus": "Dodonaea "
+    },
+    {
+      "common": "Purple Hopseed Bush",
+      "scientific": "Dodonaea viscosa 'Purpurea'",
+      "genus": "Dodonaea viscosa 'Purpurea'"
+    },
+    {
+      "common": "Purple-leaf Acacia",
+      "scientific": "Acacia baileyana 'Purpurea'",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Purple-leaf Acacia",
+      "scientific": "Acacia baileyana 'Purpurea'",
+      "genus": "Acacia baileyana 'Purpurea'"
+    },
+    {
+      "common": "Purple Leaf Plum",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Purple-Leaf Plum",
+      "scientific": "Prunus cerasifera 'Atropurpurea'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Purple-Leaf Plum",
+      "scientific": "Prunus cerasifera 'Atropurpurea'",
+      "genus": "Prunus cerasifera 'Atropurpurea'"
+    },
+    {
+      "common": "PURPLE-LEAF PLUM",
+      "scientific": "Prunus cerasifera",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Purple Leaf Plum Krauter Vesuvius",
+      "scientific": "Prunus cerasifera 'Krauter vesuvius'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Purple Leaf Plum Krauter Vesuvius",
+      "scientific": "Prunus cerasifera 'Krauter vesuvius'",
+      "genus": "Prunus cerasifera 'Krauter vesuvius'"
+    },
+    {
+      "common": "Purple-Leaf Plum 'Thundercloud'",
+      "scientific": "Prunus cerasifera 'Thundercloud'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Purple-Leaf Plum 'Thundercloud'",
+      "scientific": "Prunus cerasifera 'Thundercloud'",
+      "genus": "Prunus cerasifera 'Thundercloud'"
+    },
+    {
+      "common": "Purple Robe locust",
+      "scientific": "Robinia pseudoacacia",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple Robe locust",
+      "scientific": "Robinia 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple Robe locust",
+      "scientific": "Robinia x 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple Robe Locust",
+      "scientific": "Robinia x ambigua 'Purple Robe'",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Purple Robe Locust",
+      "scientific": "Robinia x ambigua 'Purple Robe'",
+      "genus": "Robinia x ambigua 'Purple Robe'"
+    },
+    {
+      "common": "PURPLE ROBE LOCUST",
+      "scientific": "Robinia pseudoacacia Purple Robe",
+      "genus": "Robinia "
+    },
+    {
+      "common": "Pussy Willow",
+      "scientific": "Salix discolor",
+      "genus": "Salix "
+    },
+    {
+      "common": "Pussy Willow",
+      "scientific": "Salix discolor",
+      "genus": "Salix discolor"
+    },
+    {
+      "common": "Quaking aspen",
+      "scientific": "Populus tremuloides",
+      "genus": "Populus "
+    },
+    {
+      "common": "Quaking aspen",
+      "scientific": "Populus tremuloides",
+      "genus": "Populus tremuloides"
+    },
+    {
+      "common": "Queen Palm",
+      "scientific": "Arecastrum romanzoffianum",
+      "genus": "Arecastrum "
+    },
+    {
+      "common": "Queen Palm",
+      "scientific": "Arecastrum romanzoffianum",
+      "genus": "Arecastrum romanzoffianum"
+    },
+    {
+      "common": "Queen Palm",
+      "scientific": "Syagrus romanzoffianum",
+      "genus": "Syagrus "
+    },
+    {
+      "common": "Queen Palm",
+      "scientific": "Syagrus romanzoffianum",
+      "genus": "Syagrus romanzoffianum"
+    },
+    {
+      "common": "QUEEN PALM",
+      "scientific": "Syagrus romanzoffianum",
+      "genus": "Syagrus "
+    },
+    {
+      "common": "Queensland Pittosporum",
+      "scientific": "Auranticarpa rhombifolia",
+      "genus": "Auranticarpa "
+    },
+    {
+      "common": "Queensland Pittosporum",
+      "scientific": "Auranticarpa rhombifolia",
+      "genus": "Auranticarpa rhombifolia"
+    },
+    {
+      "common": "Quercus shumardii",
+      "scientific": "Quercus agrifolia",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Quince",
+      "scientific": "Cydonia oblonga",
+      "genus": "Cydonia "
+    },
+    {
+      "common": "Raywood Ash",
+      "scientific": "Fraxinus oxycarpa 'Raywood'",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Raywood Ash",
+      "scientific": "Fraxinus oxycarpa 'Raywood'",
+      "genus": "Fraxinus oxycarpa 'Raywood'"
+    },
+    {
+      "common": "RAYWOOD ASH",
+      "scientific": "Fraxinus angustifolia oxycarpa",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Red Alder",
+      "scientific": "Alnus rubra",
+      "genus": "Alnus rubra"
+    },
+    {
+      "common": "Redbay",
+      "scientific": "Persea borbonia",
+      "genus": "Persea "
+    },
+    {
+      "common": "Red Bells",
+      "scientific": "Iochroma coccinea",
+      "genus": "Iochroma "
+    },
+    {
+      "common": "REDBUD",
+      "scientific": "Cercis spp.",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Redbud, Eastern",
+      "scientific": "Cercis canadensis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Redbud, Southwestern",
+      "scientific": "Cercis reniformis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Redbud, Texas",
+      "scientific": "Cercis canadensis var. texensis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Redbud, Western",
+      "scientific": "Cercis occidentalis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Red Bushmallow",
+      "scientific": "Combretum apiculatum",
+      "genus": "Combretum "
+    },
+    {
+      "common": "RED-CAP GUM",
+      "scientific": "Eucalyptus erythrocorys",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Redcedar, Eastern",
+      "scientific": "Juniperus virginiana",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Red Flowering Gum",
+      "scientific": "Corymbia ficifolia",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "Red Flowering Gum",
+      "scientific": "Corymbia ficifolia",
+      "genus": "Corymbia ficifolia"
+    },
+    {
+      "common": "RED FLOWERING GUM",
+      "scientific": "Corymbia ficifolia",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "RED GUM",
+      "scientific": "Eucalyptus camaldulensis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Red Horse Chestnut",
+      "scientific": "Aesculus x carnea",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Red Horse Chestnut",
+      "scientific": "Aesculus x carnea",
+      "genus": "Aesculus x carnea"
+    },
+    {
+      "common": "RED HORSECHESTNUT",
+      "scientific": "Aesculus x carnea",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Red Ironbark",
+      "scientific": "Eucalyptus sideroxylon",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Red Ironbark",
+      "scientific": "Eucalyptus sideroxylon",
+      "genus": "Eucalyptus sideroxylon"
+    },
+    {
+      "common": "RED IRONBARK",
+      "scientific": "Eucalyptus sideroxylon",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum 'Armstrong'",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum 'Bowhall'",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum 'Brandywine'",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum ?October Glory?",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer rubrum 'October Glory' october glory red maple (for front yard)",
+      "genus": "Acer "
+    },
+    {
+      "common": "red maple",
+      "scientific": "Acer species",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Maple",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Maple",
+      "scientific": "Acer rubrum",
+      "genus": "Acer rubrum"
+    },
+    {
+      "common": "Red Maple",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Maple",
+      "scientific": "Acer Rubrum October Glory",
+      "genus": "Acer"
+    },
+    {
+      "common": "RED MAPLE",
+      "scientific": "Acer rubrum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Maple Octobery Glory",
+      "scientific": "Acer Rubrum",
+      "genus": "Acer"
+    },
+    {
+      "common": "Red Maple Tree 'Autumn Glory'",
+      "scientific": "Acer rubrum 'Autumn Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Maple Tree 'Autumn Glory'",
+      "scientific": "Acer rubrum 'Autumn Glory'",
+      "genus": "Acer rubrum 'Autumn Glory'"
+    },
+    {
+      "common": "Redmond Linden",
+      "scientific": "Tilia americana 'Redmond'",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Redmond Linden",
+      "scientific": "Tilia americana 'Redmond'",
+      "genus": "Tilia americana 'Redmond'"
+    },
+    {
+      "common": "Red mulbeerry",
+      "scientific": "Morus rubra",
+      "genus": "Morus "
+    },
+    {
+      "common": "Red mulbeerry",
+      "scientific": "Morus rubra",
+      "genus": "Morus rubra"
+    },
+    {
+      "common": "Red oak",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Red Oak",
+      "scientific": "Acer buergerianum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Oak",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus"
+    },
+    {
+      "common": "Red Oak",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Red Oak",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus rubra"
+    },
+    {
+      "common": "RED OAK",
+      "scientific": "Quercus rubra",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Red Obelisk Beech",
+      "scientific": "Fagus sylvatica 'Red Obelisk'",
+      "genus": "Fagus sylvatica 'Red Obelisk'"
+    },
+    {
+      "common": "Red October Glory Maple",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red October Glory Maple",
+      "scientific": "Acer rubrum 'October Glory'",
+      "genus": "Acer rubrum 'October Glory'"
+    },
+    {
+      "common": "Red Rage tupelo",
+      "scientific": "Nyssa sylvatica 'Haymanred' (Red Rage tupelo)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Red Rage tupelo",
+      "scientific": "Nyssa sylvatica 'Red Rage' (tupelo)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Red Swamp Maple",
+      "scientific": "Acer rubrum 'Red Sunset'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Red Swamp Maple",
+      "scientific": "Acer rubrum 'Red Sunset'",
+      "genus": "Acer rubrum 'Red Sunset'"
+    },
+    {
+      "common": "Redwood, Coast",
+      "scientific": "Sequoia sempervirens",
+      "genus": "Sequoia "
+    },
+    {
+      "common": "Redwood, Dawn",
+      "scientific": "Metasequoia glyptostroboides",
+      "genus": "Metasequoia "
+    },
+    {
+      "common": "Regent Scholar Tree",
+      "scientific": "Sophora japonica 'Regent'",
+      "genus": "Sophora "
+    },
+    {
+      "common": "Regent Scholar Tree",
+      "scientific": "Sophora japonica 'Regent'",
+      "genus": "Sophora japonica 'Regent'"
+    },
+    {
+      "common": "Rhododendron",
+      "scientific": "Rhododendron species",
+      "genus": "Rhododendron "
+    },
+    {
+      "common": "river birch",
+      "scientific": "Betula nigra",
+      "genus": "Betula"
+    },
+    {
+      "common": "River Birch",
+      "scientific": "Betula nigra",
+      "genus": "Betula "
+    },
+    {
+      "common": "River Birch",
+      "scientific": "Betula nigra",
+      "genus": "Betula nigra"
+    },
+    {
+      "common": "RIVER BIRCH",
+      "scientific": "Betula nigra",
+      "genus": "Betula "
+    },
+    {
+      "common": "River Red Gum",
+      "scientific": "Eucalyptus camaldulensis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "River Red Gum",
+      "scientific": "Eucalyptus camaldulensis",
+      "genus": "Eucalyptus camaldulensis"
+    },
+    {
+      "common": "River Tamarind",
+      "scientific": "Leucaena leucocephala",
+      "genus": "Leucaena "
+    },
+    {
+      "common": "River Wattle",
+      "scientific": "Acacia cognata",
+      "genus": "Acacia "
+    },
+    {
+      "common": "River Wattle",
+      "scientific": "Acacia cognata",
+      "genus": "Acacia cognata"
+    },
+    {
+      "common": "Robusta Magnolia",
+      "scientific": "Magnolia sargentiana 'Robusta'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Rockrose, Gum",
+      "scientific": "Cistus ladanifer",
+      "genus": "Cistus "
+    },
+    {
+      "common": "ROCKY MOUNTAIN JUNIPER",
+      "scientific": "Juniperus scopulorum",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Rose-of-Sharon",
+      "scientific": "Hibiscus syriacus",
+      "genus": "Hibiscus "
+    },
+    {
+      "common": "Roundleaf sweetgum",
+      "scientific": "Liquidambar styraciflua 'Rotundiloba'",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "Roundleaf sweetgum",
+      "scientific": "Liquidambar styraciflua 'Rotundiloba'",
+      "genus": "Liquidambar styraciflua 'Rotundiloba'"
+    },
+    {
+      "common": "Royal Burgundy Flowering Cherry Tree",
+      "scientific": "Prunus serrulata 'Royal Burgundy'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Royal Burgundy Flowering Cherry Tree",
+      "scientific": "Prunus serrulata 'Royal Burgundy'",
+      "genus": "Prunus serrulata 'Royal Burgundy'"
+    },
+    {
+      "common": "Ruby Horse Chestnut",
+      "scientific": "Aesculus x carnea 'Briotii'",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "Ruby Horse Chestnut",
+      "scientific": "Aesculus x carnea 'Briotii'",
+      "genus": "Aesculus x carnea 'Briotii'"
+    },
+    {
+      "common": "Russet Magnolia",
+      "scientific": "Magnolia grandiflora 'Russet'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Russet Magnolia",
+      "scientific": "Magnolia grandiflora 'Russet'",
+      "genus": "Magnolia grandiflora 'Russet'"
+    },
+    {
+      "common": "RUSSET MAGNOLIA",
+      "scientific": "Magnolia grandiflora Russet",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "RUSSIAN OLIVE",
+      "scientific": "Elaeagnus angustifolia",
+      "genus": "Elaeagnus "
+    },
+    {
+      "common": "Sago palm",
+      "scientific": "Cycas revoluta",
+      "genus": "Cycas revoluta"
+    },
+    {
+      "common": "SAGO PALM",
+      "scientific": "Cycas revoluta",
+      "genus": "Cycas "
+    },
+    {
+      "common": "Saint Mary Magnolia",
+      "scientific": "Magnolia grandiflora 'Saint Mary'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Saint Mary Magnolia",
+      "scientific": "Magnolia grandiflora 'Saint Mary'",
+      "genus": "Magnolia grandiflora 'Saint Mary'"
+    },
+    {
+      "common": "SAINT MARY MAGNOLIA",
+      "scientific": "Magnolia grandiflora Saint Mary",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Samuel Sommer Magnolia",
+      "scientific": "Magnolia grandiflora 'Samuel Sommer'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Samuel Sommer Magnolia",
+      "scientific": "Magnolia grandiflora 'Samuel Sommer'",
+      "genus": "Magnolia grandiflora 'Samuel Sommer'"
+    },
+    {
+      "common": "SAND PEAR",
+      "scientific": "Pyrus pyrifolia",
+      "genus": "Pyrus "
+    },
+    {
+      "common": "San Jose hesper palm",
+      "scientific": "Brahea brandegeei",
+      "genus": "Brahea brandegeei"
+    },
+    {
+      "common": "Santa Cruz Ironwood",
+      "scientific": "Lyonothamnus floribundus subsp. asplenifolius",
+      "genus": "Lyonothamnus "
+    },
+    {
+      "common": "Santa Cruz Ironwood",
+      "scientific": "Lyonothamnus floribundus subsp. asplenifolius",
+      "genus": "Lyonothamnus floribundus subsp. asplenifolius"
+    },
+    {
+      "common": "Santa Rosa Plum",
+      "scientific": "",
+      "genus": ""
+    },
+    {
+      "common": "Santa Rosa Plum",
+      "scientific": "Prunus domestica 'Santa Rosa'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Santa Rosa Plum",
+      "scientific": "Prunus domestica 'Santa Rosa'",
+      "genus": "Prunus domestica 'Santa Rosa'"
+    },
+    {
+      "common": "Santa Rosa Plum",
+      "scientific": "Prunus salicina 'Santa Rosa'",
+      "genus": "Prunus"
+    },
+    {
+      "common": "Saratoga laurel",
+      "scientific": "Laurus nobilis 'Saratoga'",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Saratoga laurel",
+      "scientific": "Laurus nobilis 'Saratoga' (replace Quercus lobata/ valley oak)",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Saratoga laurel",
+      "scientific": "Laurus nobilis 'Saratoga' (Saratoga laurel)",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Saratoga Laurel",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Saratoga Laurel",
+      "scientific": "Laurus nobilis 'Saratoga'",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Sargent Cherry",
+      "scientific": "Prunus sargentii",
+      "genus": "Prunus sargentii"
+    },
+    {
+      "common": "Sargent Cherry Tree 'Columnaris'",
+      "scientific": "Prunus sargentii 'Columnaris'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Saucer Magnolia",
+      "scientific": "Magnolia x soulangiana",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Saucer Magnolia",
+      "scientific": "Magnolia x soulangiana",
+      "genus": "Magnolia x soulangiana"
+    },
+    {
+      "common": "SAUCER MAGNOLIA",
+      "scientific": "Magnolia soulangiana",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "sawleaf zelkova",
+      "scientific": "Zelkova serrata 'Green Vase'",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "sawleaf zelkova",
+      "scientific": "Zelkova serrata 'Village Green'",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "Sawleaf Zelkova",
+      "scientific": "Zelkova serrata",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "Sawleaf Zelkova",
+      "scientific": "Zelkova serrata",
+      "genus": "Zelkova serrata"
+    },
+    {
+      "common": "sawtooth zelkova",
+      "scientific": "Zelkova serrata 'Green Vase'",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "SAWTOOTH ZELKOVA",
+      "scientific": "Zelkova serrata",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "Scarlet beebalm",
+      "scientific": "Monarda didyma",
+      "genus": "Monarda "
+    },
+    {
+      "common": "scarlet oak",
+      "scientific": "Quercus coccinea",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Scarlet Oak",
+      "scientific": "Quercus coccinea",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Scarlet Oak",
+      "scientific": "Quercus coccinea",
+      "genus": "Quercus coccinea"
+    },
+    {
+      "common": "SCARLET OAK",
+      "scientific": "Quercus coccinea",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Scotch Elm",
+      "scientific": "Ulmus glabra",
+      "genus": "Ulmus glabra"
+    },
+    {
+      "common": "Scots Pine",
+      "scientific": "Pinus sylvestris",
+      "genus": "Pinus sylvestris"
+    },
+    {
+      "common": "Sea Urchin Tree",
+      "scientific": "Hakea laurina",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Sea Urchin Tree",
+      "scientific": "Hakea laurina",
+      "genus": "Hakea laurina"
+    },
+    {
+      "common": "Seedless Lime",
+      "scientific": "Citrus aurantifolia 'Bearss'",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Seedless Lime",
+      "scientific": "Citrus aurantifolia 'Bearss'",
+      "genus": "Citrus aurantifolia 'Bearss'"
+    },
+    {
+      "common": "Select tupelo",
+      "scientific": "Nyssa sylvatica 'Select'",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Senegal date palm",
+      "scientific": "Phoenix reclinata",
+      "genus": "Phoenix "
+    },
+    {
+      "common": "Senegal date palm",
+      "scientific": "Phoenix reclinata",
+      "genus": "Phoenix reclinata"
+    },
+    {
+      "common": "Senna, Lindheimer",
+      "scientific": "Senna lindheimeriana",
+      "genus": "Senna "
+    },
+    {
+      "common": "Sensation boxelder",
+      "scientific": "Acer negundo",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sensation boxelder",
+      "scientific": "Acer negundo 'Sensation'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sensation boxelder",
+      "scientific": "Acer negundo 'Sensation' (boxelder)",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sensation Boxelder",
+      "scientific": "Acer negundo",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sequoia, Giant",
+      "scientific": "Sequoiadendron giganteum",
+      "genus": "Sequoiadendron "
+    },
+    {
+      "common": "Serviceberry",
+      "scientific": "Amelanchier species",
+      "genus": "Amelanchier "
+    },
+    {
+      "common": "SHAMEL ASH",
+      "scientific": "Fraxinus uhdei",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Shamel Ash: Evergreen Ash",
+      "scientific": "Fraxinus uhdei",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Shamel Ash: Evergreen Ash",
+      "scientific": "Fraxinus uhdei",
+      "genus": "Fraxinus uhdei"
+    },
+    {
+      "common": "Sheoak, River",
+      "scientific": "Casuarina cunninghamiana",
+      "genus": "Casuarina "
+    },
+    {
+      "common": "Shoestring Acacia",
+      "scientific": "Acacia stenophylla",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Shoestring Acacia",
+      "scientific": "Acacia stenophylla",
+      "genus": "Acacia stenophylla"
+    },
+    {
+      "common": "Shore Pine",
+      "scientific": "Pinus contorta",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Showy Crab Apple: Japanese Crabapple",
+      "scientific": "Malus floribunda",
+      "genus": "Malus "
+    },
+    {
+      "common": "Showy Crab Apple: Japanese Crabapple",
+      "scientific": "Malus floribunda",
+      "genus": "Malus floribunda"
+    },
+    {
+      "common": "Shrub",
+      "scientific": "Shrub",
+      "genus": ""
+    },
+    {
+      "common": "Shrub",
+      "scientific": "Shrub",
+      "genus": "Shrub"
+    },
+    {
+      "common": "Shumard oak",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Shumard red oak",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "SHUMARD RED OAK",
+      "scientific": "Quercus shumardii",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Siberian Elm",
+      "scientific": "Ulmus pumila",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Siberian Elm",
+      "scientific": "Ulmus pumila",
+      "genus": "Ulmus pumila"
+    },
+    {
+      "common": "Sidney Blue Gum",
+      "scientific": "Eucalyptus saligna",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Sidney Blue Gum",
+      "scientific": "Eucalyptus saligna",
+      "genus": "Eucalyptus saligna"
+    },
+    {
+      "common": "Sierra Redwood",
+      "scientific": "Sequoiadendron giganteum",
+      "genus": "Sequoiadendron "
+    },
+    {
+      "common": "Sierra Redwood",
+      "scientific": "Sequoiadendron giganteum",
+      "genus": "Sequoiadendron giganteum"
+    },
+    {
+      "common": "Silk floss",
+      "scientific": "Ceiba speciosa",
+      "genus": "Ceiba "
+    },
+    {
+      "common": "Silk floss",
+      "scientific": "Ceiba speciosa",
+      "genus": "Ceiba speciosa"
+    },
+    {
+      "common": "Silk Floss Tree",
+      "scientific": "Ceiba speciosa",
+      "genus": "Ceiba "
+    },
+    {
+      "common": "Silk Floss Tree",
+      "scientific": "Chorisia speciosa",
+      "genus": "Chorisia "
+    },
+    {
+      "common": "Silk Floss Tree",
+      "scientific": "Chorisia speciosa",
+      "genus": "Chorisia speciosa"
+    },
+    {
+      "common": "SILK OAK",
+      "scientific": "Grevillea robusta",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Silkoak species",
+      "scientific": "Grevillea spp",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Silkoak species",
+      "scientific": "Grevillea spp",
+      "genus": "Grevillea spp"
+    },
+    {
+      "common": "Silk Oak Tree",
+      "scientific": "Grevillea robusta",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Silk Oak Tree",
+      "scientific": "Grevillea robusta",
+      "genus": "Grevillea robusta"
+    },
+    {
+      "common": "Silk Oak Tree 'Red Hooks'",
+      "scientific": "Grevillea 'Red Hooks'",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Silk Oak Tree 'Red Hooks'",
+      "scientific": "Grevillea 'Red Hooks'",
+      "genus": "Grevillea 'Red Hooks'"
+    },
+    {
+      "common": "SILK TREE",
+      "scientific": "Albizia julibrissin",
+      "genus": "Albizia "
+    },
+    {
+      "common": "Silky-oak",
+      "scientific": "Grevillea robusta",
+      "genus": "Grevillea "
+    },
+    {
+      "common": "Silvercloud Magnolia",
+      "scientific": "Magnolia doltsopa 'Silvercloud'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Silvercloud Magnolia",
+      "scientific": "Magnolia doltsopa 'Silvercloud'",
+      "genus": "Magnolia doltsopa 'Silvercloud'"
+    },
+    {
+      "common": "Silver Dollar Eucalyptus",
+      "scientific": "Eucalyptus polyanthemos",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Silver Dollar Eucalyptus",
+      "scientific": "Eucalyptus polyanthemos",
+      "genus": "Eucalyptus polyanthemos"
+    },
+    {
+      "common": "SILVER DOLLAR GUM",
+      "scientific": "Eucalyptus polyanthemos",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "silver linden",
+      "scientific": "Geijera parviflora/ australian willow",
+      "genus": "Geijera "
+    },
+    {
+      "common": "silver linden",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia "
+    },
+    {
+      "common": "silver linden",
+      "scientific": "Tilia tomentosa (silver linden)",
+      "genus": "Tilia "
+    },
+    {
+      "common": "silver linden",
+      "scientific": "Tilia tomentosa Silver Linden",
+      "genus": "Tilia "
+    },
+    {
+      "common": "silver linden",
+      "scientific": "Tilia tomentosa 'Sterling'",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Silver Linden",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia"
+    },
+    {
+      "common": "Silver Linden",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Silver Linden",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia tomentosa"
+    },
+    {
+      "common": "SILVER LINDEN",
+      "scientific": "Tilia tomentosa",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Silver Maple",
+      "scientific": "Acer saccharinum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Silver Maple",
+      "scientific": "Acer saccharinum",
+      "genus": "Acer saccharinum"
+    },
+    {
+      "common": "SILVER MAPLE",
+      "scientific": "Acer saccharinum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Silver Mountain Gum Tree",
+      "scientific": "Eucalyptus pulverulenta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Silver Mountain Gum Tree",
+      "scientific": "Eucalyptus pulverulenta",
+      "genus": "Eucalyptus pulverulenta"
+    },
+    {
+      "common": "Silver Tree",
+      "scientific": "Leucadendron argenteum",
+      "genus": "Leucadendron "
+    },
+    {
+      "common": "Silver Tree",
+      "scientific": "Leucodendron argenteum",
+      "genus": "Leucodendron "
+    },
+    {
+      "common": "Silver Tree",
+      "scientific": "Leucodendron argenteum",
+      "genus": "Leucodendron argenteum"
+    },
+    {
+      "common": "Silver Wattle",
+      "scientific": "Acacia dealbata",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Silver Wattle",
+      "scientific": "Acacia dealbata",
+      "genus": "Acacia dealbata"
+    },
+    {
+      "common": "Simmond's Peppermint",
+      "scientific": "Eucalyptus simmondsi",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Small-leaf Tristania 'Elegant'",
+      "scientific": "Tristaniopsis laurina 'Elegant'",
+      "genus": "Tristaniopsis "
+    },
+    {
+      "common": "Small-leaf Tristania 'Elegant'",
+      "scientific": "Tristaniopsis laurina 'Elegant'",
+      "genus": "Tristaniopsis laurina 'Elegant'"
+    },
+    {
+      "common": "Smoke tree",
+      "scientific": "Cotinus coggygria 'Royal Purple'",
+      "genus": "Cotinus "
+    },
+    {
+      "common": "Smoke tree",
+      "scientific": "Cotinus coggygria 'Royal Purple'",
+      "genus": "Cotinus coggygria 'Royal Purple'"
+    },
+    {
+      "common": "Smoketree",
+      "scientific": "Cotinus coggygria",
+      "genus": "Cotinus "
+    },
+    {
+      "common": "Snag",
+      "scientific": "Snag",
+      "genus": ""
+    },
+    {
+      "common": "Snowdrop Tree",
+      "scientific": "Halesia carolina",
+      "genus": "Halesia "
+    },
+    {
+      "common": "Soapberry, Western",
+      "scientific": "Sapindus drummondii",
+      "genus": "Sapindus "
+    },
+    {
+      "common": "Soft Tree Fern",
+      "scientific": "Dicksonia antarctica",
+      "genus": "Dicksonia "
+    },
+    {
+      "common": "Soft Tree Fern",
+      "scientific": "Dicksonia antarctica",
+      "genus": "Dicksonia antarctica"
+    },
+    {
+      "common": "SOLANUM",
+      "scientific": "Solanum spp.",
+      "genus": "Solanum "
+    },
+    {
+      "common": "Solanum rantonnetti",
+      "scientific": "Solanum rantonnetti",
+      "genus": "Solanum "
+    },
+    {
+      "common": "Solanum rantonnetti",
+      "scientific": "Solanum rantonnetti",
+      "genus": "Solanum rantonnetti"
+    },
+    {
+      "common": "SOUR GUM",
+      "scientific": "Nyssa sylvatica",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Sourwood",
+      "scientific": "Oxydendrum arboreum",
+      "genus": "Oxydendrum "
+    },
+    {
+      "common": "Southern Live Oak",
+      "scientific": "Quercus virginiana",
+      "genus": "Quercus"
+    },
+    {
+      "common": "Southern Live Oak",
+      "scientific": "Quercus virginiana",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Southern Live Oak",
+      "scientific": "Quercus virginiana",
+      "genus": "Quercus virginiana"
+    },
+    {
+      "common": "SOUTHERN LIVE OAK",
+      "scientific": "Quercus virginiana",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Southern magnolia",
+      "scientific": "Magnolia grandiflora 'Majestic Beauty'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Southern magnolia",
+      "scientific": "Magnolia grandiflora 'Majestic Beauty' (Southern magnolia)",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Southern magnolia",
+      "scientific": "Magnolia grandiflora 'Samuel Sommer' (Southern Magnolia)",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Southern Magnolia",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Southern Magnolia",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia grandiflora"
+    },
+    {
+      "common": "SOUTHERN MAGNOLIA",
+      "scientific": "Magnolia grandiflora",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "Southern red cedar",
+      "scientific": "Juniperus silicicola",
+      "genus": "Juniperus "
+    },
+    {
+      "common": "Spanish bayonet",
+      "scientific": "Yucca aloifolia",
+      "genus": "Yucca aloifolia"
+    },
+    {
+      "common": "Spanish Dagger",
+      "scientific": "Yucca gloriosa",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Spanish Dagger",
+      "scientific": "Yucca gloriosa",
+      "genus": "Yucca gloriosa"
+    },
+    {
+      "common": "Spiked Cabbage Tree",
+      "scientific": "Cussonia spicata",
+      "genus": "Cussonia "
+    },
+    {
+      "common": "Spotted Gum",
+      "scientific": "Corymbia maculata",
+      "genus": "Corymbia "
+    },
+    {
+      "common": "Spotted Gum",
+      "scientific": "Corymbia maculata",
+      "genus": "Corymbia maculata"
+    },
+    {
+      "common": "Spruce",
+      "scientific": "Picea species",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce, Black",
+      "scientific": "Picea mariana",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce, Blue",
+      "scientific": "Picea pungens",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce, Norway",
+      "scientific": "Picea abies",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce, Sitka",
+      "scientific": "Picea sitchensis",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce Spp",
+      "scientific": "Picea Spp",
+      "genus": "Picea "
+    },
+    {
+      "common": "Spruce Spp",
+      "scientific": "Picea Spp",
+      "genus": "Picea Spp"
+    },
+    {
+      "common": "Spruce, White",
+      "scientific": "Picea glauca",
+      "genus": "Picea "
+    },
+    {
+      "common": "Staghorn sumac",
+      "scientific": "Rhus typhina",
+      "genus": "Rhus typhina"
+    },
+    {
+      "common": "Sterling Silver Linden",
+      "scientific": "Tilia tomentosa 'Sterling'",
+      "genus": "Tilia "
+    },
+    {
+      "common": "STERLING SILVER LINDEN",
+      "scientific": "Tilia tomentosa Sterling",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Stewart Avocado",
+      "scientific": "Persea americana 'Stewart'",
+      "genus": "Persea "
+    },
+    {
+      "common": "STONE FRUIT",
+      "scientific": "Prunus spp.",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Strawberry tree",
+      "scientific": "Arbutus 'Marina'",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Strawberry Tree",
+      "scientific": "Arbutus unedo",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Strawberry Tree",
+      "scientific": "Arbutus unedo",
+      "genus": "Arbutus unedo"
+    },
+    {
+      "common": "STRAWBERRY TREE",
+      "scientific": "Arbutus unedo",
+      "genus": "Arbutus "
+    },
+    {
+      "common": "Stump",
+      "scientific": "Stump",
+      "genus": ""
+    },
+    {
+      "common": "STUMP",
+      "scientific": "Stump",
+      "genus": ""
+    },
+    {
+      "common": "Sugar-apple",
+      "scientific": "Annona squamosa",
+      "genus": "Annona "
+    },
+    {
+      "common": "sugar maple",
+      "scientific": "Acer saccharum 'Endowment'",
+      "genus": "Acer "
+    },
+    {
+      "common": "sugar maple",
+      "scientific": "Acer saccharum 'Fall Fiesta'",
+      "genus": "Acer "
+    },
+    {
+      "common": "sugar maple",
+      "scientific": "Acer saccharum 'Wright Brothers'",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sugar Maple",
+      "scientific": "Acer saccharum",
+      "genus": "Acer "
+    },
+    {
+      "common": "SUGAR MAPLE",
+      "scientific": "Acer saccharum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sumac, African",
+      "scientific": "Rhus lancea",
+      "genus": "Rhus "
+    },
+    {
+      "common": "Sumac, Skunkbush",
+      "scientific": "Rhus typhina",
+      "genus": "Rhus "
+    },
+    {
+      "common": "Sumac, Smooth",
+      "scientific": "Rhus glabra",
+      "genus": "Rhus "
+    },
+    {
+      "common": "Sunburst Honey Locust",
+      "scientific": "Gleditsia triacanthos 'Sunburst'",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Sunburst Honey Locust",
+      "scientific": "Gleditsia triacanthos 'Sunburst'",
+      "genus": "Gleditsia triacanthos 'Sunburst'"
+    },
+    {
+      "common": "SURINAM CHERRY",
+      "scientific": "Eugenia uniflora",
+      "genus": "Eugenia "
+    },
+    {
+      "common": "Swamp Gum: Flooded Gum",
+      "scientific": "Eucalyptus rudis",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Swamp Gum: Flooded Gum",
+      "scientific": "Eucalyptus rudis",
+      "genus": "Eucalyptus rudis"
+    },
+    {
+      "common": "Swamp mahogany",
+      "scientific": "Eucalyptus robusta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Swamp mahogany",
+      "scientific": "Eucalyptus robusta",
+      "genus": "Eucalyptus robusta"
+    },
+    {
+      "common": "SWAMP MAHOGONY",
+      "scientific": "Eucalyptus robusta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Swamp Myrtle",
+      "scientific": "Tristaniopsis laurina",
+      "genus": "Tristaniopsis "
+    },
+    {
+      "common": "Swamp Myrtle",
+      "scientific": "Tristaniopsis laurina",
+      "genus": "Tristaniopsis laurina"
+    },
+    {
+      "common": "Swamp paperbark",
+      "scientific": "Melaleuca ericifolia",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "SWAN HILL OLIVE",
+      "scientific": "Olea europaea Swan Hill",
+      "genus": "Olea "
+    },
+    {
+      "common": "SWEET BAY",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Sweet Bay: Grecian Laurel",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus "
+    },
+    {
+      "common": "Sweet Bay: Grecian Laurel",
+      "scientific": "Laurus nobilis",
+      "genus": "Laurus nobilis"
+    },
+    {
+      "common": "Sweetgum, Chinese",
+      "scientific": "Liquidambar formosana",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "Sweetgum, Common",
+      "scientific": "Liquidambar styraciflua",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "Sweetgum, Oriental",
+      "scientific": "Liquidambar orientalis",
+      "genus": "Liquidambar "
+    },
+    {
+      "common": "SWEET HAKEA",
+      "scientific": "Hakea suaveolens",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Sweet Hakea Tree",
+      "scientific": "Hakea suaveolens",
+      "genus": "Hakea "
+    },
+    {
+      "common": "Sweet Hakea Tree",
+      "scientific": "Hakea suaveolens",
+      "genus": "Hakea suaveolens"
+    },
+    {
+      "common": "Sweet Olive",
+      "scientific": "Osmanthus fragrans",
+      "genus": "Osmanthus "
+    },
+    {
+      "common": "Sweetshade",
+      "scientific": "Hymenosporum flavum",
+      "genus": "Hymenosporum "
+    },
+    {
+      "common": "Sweetshade",
+      "scientific": "Hymenosporum flavum",
+      "genus": "Hymenosporum flavum"
+    },
+    {
+      "common": "Sweet Shade",
+      "scientific": "Hymenosporum flavum",
+      "genus": "Hymenosporum "
+    },
+    {
+      "common": "Sweet Shade",
+      "scientific": "Hymenosporum flavum",
+      "genus": "Hymenosporum flavum"
+    },
+    {
+      "common": "Sweet viburnum",
+      "scientific": "Viburnum odoratissimum var. awabuki",
+      "genus": "Viburnum "
+    },
+    {
+      "common": "Sweet viburnum",
+      "scientific": "Viburnum odoratissimum var. awabuki",
+      "genus": "Viburnum odoratissimum var. awabuki"
+    },
+    {
+      "common": "SYCAMORE",
+      "scientific": "Platanus spp.",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Sycamore, American",
+      "scientific": "Platanus occidentalis",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Sycamore, California",
+      "scientific": "Platanus racemosa",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Sycamore: London Plane",
+      "scientific": "Platanus x hispanica",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Sycamore: London Plane",
+      "scientific": "Platanus x hispanica",
+      "genus": "Platanus x hispanica"
+    },
+    {
+      "common": "Sycamore Maple",
+      "scientific": "Acer pseudoplatanus",
+      "genus": "Acer "
+    },
+    {
+      "common": "Sycamore Maple",
+      "scientific": "Acer pseudoplatanus",
+      "genus": "Acer pseudoplatanus"
+    },
+    {
+      "common": "Taiwan Flowering Cherry",
+      "scientific": "Prunus campanulata",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Taiwan Flowering Cherry",
+      "scientific": "Prunus campanulata",
+      "genus": "Prunus campanulata"
+    },
+    {
+      "common": "Tallowtree",
+      "scientific": "Triadica sebifera",
+      "genus": "Triadica "
+    },
+    {
+      "common": "tangelo",
+      "scientific": "Tangelo",
+      "genus": ""
+    },
+    {
+      "common": "tangelo",
+      "scientific": "Tangelo Minneola",
+      "genus": "Tangelo "
+    },
+    {
+      "common": "TANGERINE",
+      "scientific": "Citrus reticulata",
+      "genus": "Citrus "
+    },
+    {
+      "common": "Tan Oak",
+      "scientific": "Lithocarpus densiflorus",
+      "genus": "Lithocarpus densiflorus"
+    },
+    {
+      "common": "Tarata",
+      "scientific": "Pittosporum eugenioides",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Tarata",
+      "scientific": "Pittosporum eugenioides",
+      "genus": "Pittosporum eugenioides"
+    },
+    {
+      "common": "TARATA",
+      "scientific": "Pittosporum eugenioides",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Tawhiwhi Pittosporum",
+      "scientific": "Pittosporum tenuifolium",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Tawhiwhi Pittosporum",
+      "scientific": "Pittosporum tenuifolium",
+      "genus": "Pittosporum tenuifolium"
+    },
+    {
+      "common": "Tea Tree",
+      "scientific": "Leptospermum quinquenervia",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Tea Tree",
+      "scientific": "Leptospermum quinquenervia",
+      "genus": "Leptospermum quinquenervia"
+    },
+    {
+      "common": "TEA TREE",
+      "scientific": "Leptospermum scoparium",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "TEA TREE",
+      "scientific": "Leptospermum spp.",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "Teatree, Coastal",
+      "scientific": "Leptospermum laevigata",
+      "genus": "Leptospermum "
+    },
+    {
+      "common": "thornless honeylocust",
+      "scientific": "Gleditsia t.i. 'Shademaster'",
+      "genus": "Gleditsia "
+    },
+    {
+      "common": "Thunderhead Pine",
+      "scientific": "Pinus thunbergii 'Thunderhead'",
+      "genus": "Pinus thunbergii 'Thunderhead'"
+    },
+    {
+      "common": "Tilia tomentosa 'Green Mountain'",
+      "scientific": "Tilia cordata",
+      "genus": "Tilia "
+    },
+    {
+      "common": "Timeless Beauty Southern Magnolia",
+      "scientific": "Magnolia grandiflora 'Timeless Beauty'",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "TIPU",
+      "scientific": "Tipuana tipu",
+      "genus": "Tipuana "
+    },
+    {
+      "common": "Tipu Tree",
+      "scientific": "Tipuana tipu",
+      "genus": "Tipuana "
+    },
+    {
+      "common": "Tomlinson Ash",
+      "scientific": "Fraxinus uhdei 'Tomlinson'",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "Toothed Azara",
+      "scientific": "Azara dentata",
+      "genus": "Azara "
+    },
+    {
+      "common": "Torrey Pine",
+      "scientific": "Pinus torreyana",
+      "genus": "Pinus "
+    },
+    {
+      "common": "Toyon",
+      "scientific": "Heteromeles arbutifolia",
+      "genus": "Heteromeles "
+    },
+    {
+      "common": "Toyon",
+      "scientific": "Heteromeles arbutifolia",
+      "genus": "Heteromeles arbutifolia"
+    },
+    {
+      "common": "Tree aloe",
+      "scientific": "Aloe barberae",
+      "genus": "Aloe "
+    },
+    {
+      "common": "Tree aloe",
+      "scientific": "Aloe barberae",
+      "genus": "Aloe barberae"
+    },
+    {
+      "common": "Tree of Heaven",
+      "scientific": "Ailanthus altissima",
+      "genus": "Ailanthus "
+    },
+    {
+      "common": "Tree Of Heaven",
+      "scientific": "Ailanthus altissima",
+      "genus": "Ailanthus "
+    },
+    {
+      "common": "Tree Of Heaven",
+      "scientific": "Ailanthus altissima",
+      "genus": "Ailanthus altissima"
+    },
+    {
+      "common": "TREE OF HEAVEN",
+      "scientific": "Ailanthus altissima",
+      "genus": "Ailanthus "
+    },
+    {
+      "common": "Tree, Unknown",
+      "scientific": "Unknown Tree",
+      "genus": "Unknown "
+    },
+    {
+      "common": "Triangle palm",
+      "scientific": "Dypsis decaryi",
+      "genus": "Dypsis "
+    },
+    {
+      "common": "Trident Maple",
+      "scientific": "Acer buergeranum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Trident Maple",
+      "scientific": "Acer buergeranum",
+      "genus": "Acer buergeranum"
+    },
+    {
+      "common": "Trident Maple",
+      "scientific": "Acer buergerianum",
+      "genus": "Acer"
+    },
+    {
+      "common": "Trident Maple",
+      "scientific": "Acer buergerianum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Trident Maple",
+      "scientific": "Pistacia chinensis",
+      "genus": "Pistacia "
+    },
+    {
+      "common": "TRIDENT MAPLE",
+      "scientific": "Acer buergeranum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Tristania conferta",
+      "scientific": "Tristania conferta",
+      "genus": "Tristania conferta"
+    },
+    {
+      "common": "True Green Chinese Elm",
+      "scientific": "Ulmus parvifolia 'True Green'",
+      "genus": "Ulmus parvifolia 'True Green'"
+    },
+    {
+      "common": "TRUE GREEN ELM",
+      "scientific": "Ulmus parvifolia True Green",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Trumpet bush",
+      "scientific": "Tecoma stans",
+      "genus": "Tecoma "
+    },
+    {
+      "common": "Trumpet Creeper",
+      "scientific": "Campsis radicans",
+      "genus": "Campsis "
+    },
+    {
+      "common": "Tulip Tree",
+      "scientific": "Liriodendron tulipifera",
+      "genus": "Liriodendron "
+    },
+    {
+      "common": "Tulip Tree",
+      "scientific": "Liriodendron tulipifera",
+      "genus": "Liriodendron tulipifera"
+    },
+    {
+      "common": "TULIP TREE",
+      "scientific": "Liriodendron tulipifera",
+      "genus": "Liriodendron "
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Haymanred' (Red Rage)",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Haymanred' (Red Rage tupelo)",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Haymanred' Red Rage tupelo",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Tupelo Tower'",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Wildfire'",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Nyssa sylvatica 'Wildfire' Tupelo",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "tupelo",
+      "scientific": "Wildfire Tupelo (Nyssa sylvatica 'Wildfire')",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "Tupelo, Black",
+      "scientific": "Nyssa sylvatica",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Tupelo, Black",
+      "scientific": "Nyssa sylvatica 'David Odom' (Afterburner)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Tupelo, Black",
+      "scientific": "Nyssa sylvatica 'Haymanred' (Red Rage tupelo)",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Tupelo, Black",
+      "scientific": "Nyssa sylvatica 'Majestic'",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Tupelo: Sour Gum",
+      "scientific": "Nyssa sylvatica",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Tupelo: Sour Gum",
+      "scientific": "Nyssa sylvatica",
+      "genus": "Nyssa sylvatica"
+    },
+    {
+      "common": "Tupelo Tower tupelo",
+      "scientific": "Nyssa sylvatica 'Tupelo Tower'",
+      "genus": "Nyssa"
+    },
+    {
+      "common": "Tupelo, Water",
+      "scientific": "Nyssa aquatica",
+      "genus": "Nyssa "
+    },
+    {
+      "common": "Turkish hazel",
+      "scientific": "Corylus colurna",
+      "genus": "Corylus "
+    },
+    {
+      "common": "Turkish hazel",
+      "scientific": "Corylus colurna (Turkish hazel)",
+      "genus": "Corylus "
+    },
+    {
+      "common": "TURKISH HAZELNUT",
+      "scientific": "Corylus colurna",
+      "genus": "Corylus "
+    },
+    {
+      "common": "Tuscarora Crape Myrtle",
+      "scientific": "Lagerstroemia indica 'Tuscarora'",
+      "genus": "Lagerstroemia indica 'Tuscarora'"
+    },
+    {
+      "common": "Tuscarora Crape Myrtle",
+      "scientific": "Lagerstroemia x 'Tuscarora'",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "TUSCARORA CRAPE MYRTLE",
+      "scientific": "Lagerstroemia indica Tuscarora",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "Ulmus Frontier",
+      "scientific": "Ulmus Frontier",
+      "genus": "Ulmus"
+    },
+    {
+      "common": "Umbrella tree",
+      "scientific": "Schefflera species",
+      "genus": "Schefflera "
+    },
+    {
+      "common": "Umbrella tree",
+      "scientific": "Schefflera species",
+      "genus": "Schefflera species"
+    },
+    {
+      "common": "UNIDENTIFIED TREE",
+      "scientific": "Unidentified spp.",
+      "genus": "Unidentified "
+    },
+    {
+      "common": "UNSUITABLE SITE",
+      "scientific": "Unsuitable site",
+      "genus": "Unsuitable "
+    },
+    {
+      "common": "Upright European Hornbeam",
+      "scientific": "Carpinus betulus 'Fastigiata'",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Upright European Hornbeam",
+      "scientific": "Carpinus betulus 'Fastigiata'",
+      "genus": "Carpinus betulus 'Fastigiata'"
+    },
+    {
+      "common": "UPRIGHT HORNBEAM",
+      "scientific": "Carpinus betulus fastigiata",
+      "genus": "Carpinus "
+    },
+    {
+      "common": "Upright Liquidambar",
+      "scientific": "Liquidambar styraciflua 'Slender Silhoutte'",
+      "genus": "Liquidambar styraciflua 'Slender Silhoutte'"
+    },
+    {
+      "common": "Vacant Site",
+      "scientific": "",
+      "genus": ""
+    },
+    {
+      "common": "VACANT SITE",
+      "scientific": "",
+      "genus": ""
+    },
+    {
+      "common": "VACANT SITE",
+      "scientific": "Vacant site",
+      "genus": "Vacant "
+    },
+    {
+      "common": "valley oak",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "valley oak",
+      "scientific": "Quercus lobata Valley Oak",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Valley Oak",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus"
+    },
+    {
+      "common": "Valley Oak",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Valley Oak",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus lobata"
+    },
+    {
+      "common": "VALLEY OAK",
+      "scientific": "Quercus lobata",
+      "genus": "Quercus "
+    },
+    {
+      "common": "Viburnum",
+      "scientific": "Viburnum species",
+      "genus": "Viburnum "
+    },
+    {
+      "common": "Victorian Box",
+      "scientific": "Pittosporum undulatum",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Victorian Box",
+      "scientific": "Pittosporum undulatum",
+      "genus": "Pittosporum undulatum"
+    },
+    {
+      "common": "VICTORIAN BOX",
+      "scientific": "Pittosporum undulatum",
+      "genus": "Pittosporum "
+    },
+    {
+      "common": "Village Green Zelkova",
+      "scientific": "Zelkova serrata 'Village Green'",
+      "genus": "Zelkova "
+    },
+    {
+      "common": "Village Green Zelkova",
+      "scientific": "Zelkova serrata 'Village Green'",
+      "genus": "Zelkova serrata 'Village Green'"
+    },
+    {
+      "common": "Vine Maple",
+      "scientific": "Acer circinatum",
+      "genus": "Acer "
+    },
+    {
+      "common": "Vine Maple",
+      "scientific": "Acer circinatum",
+      "genus": "Acer circinatum"
+    },
+    {
+      "common": "WALNUT",
+      "scientific": "Juglans spp.",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut, Black",
+      "scientific": "Juglans nigra",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut: Black (n.calif)",
+      "scientific": "Juglans hindsii",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut: Black (n.calif)",
+      "scientific": "Juglans hindsii",
+      "genus": "Juglans hindsii"
+    },
+    {
+      "common": "Walnut: Black (s.calif)",
+      "scientific": "Juglans californica",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut: Black (s.calif)",
+      "scientific": "Juglans californica",
+      "genus": "Juglans californica"
+    },
+    {
+      "common": "Walnut, English",
+      "scientific": "Juglans regia",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut: English",
+      "scientific": "Juglans regia",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Walnut: English",
+      "scientific": "Juglans regia",
+      "genus": "Juglans regia"
+    },
+    {
+      "common": "Walnut, Hind",
+      "scientific": "Juglans hindsii",
+      "genus": "Juglans "
+    },
+    {
+      "common": "Washington Hawthorn",
+      "scientific": "Crataegus phaenopyrum",
+      "genus": "Crataegus "
+    },
+    {
+      "common": "Washington Hawthorn",
+      "scientific": "Crataegus phaenopyrum",
+      "genus": "Crataegus phaenopyrum"
+    },
+    {
+      "common": "Washingtonia, Mexican",
+      "scientific": "Washingtonia robusta",
+      "genus": "Washingtonia "
+    },
+    {
+      "common": "WATERBUSH",
+      "scientific": "Myoporum acuminatum",
+      "genus": "Myoporum "
+    },
+    {
+      "common": "WATER GUM",
+      "scientific": "Tristaniopsis laurina",
+      "genus": "Tristaniopsis "
+    },
+    {
+      "common": "Wattle, Silver",
+      "scientific": "Acacia dealbata",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Wattle, Sydney Golden",
+      "scientific": "Acacia longifolia",
+      "genus": "Acacia "
+    },
+    {
+      "common": "W-Driveway within 6",
+      "scientific": "W-Driveway within 6",
+      "genus": "W-Driveway "
+    },
+    {
+      "common": "Weeping Bottlebrush",
+      "scientific": "Callistemon viminalis",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "Weeping Bottlebrush",
+      "scientific": "Callistemon viminalis",
+      "genus": "Callistemon viminalis"
+    },
+    {
+      "common": "WEEPING BOTTLEBRUSH",
+      "scientific": "Melaleuca viminalis",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Weeping Cherry",
+      "scientific": "Prunus subhirtella 'Pendula'",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Weeping Cherry",
+      "scientific": "Prunus subhirtella 'Pendula'",
+      "genus": "Prunus subhirtella 'Pendula'"
+    },
+    {
+      "common": "Weeping Chinese Elm",
+      "scientific": "Ulmus parvifolia 'Sempervirens'",
+      "genus": "Ulmus "
+    },
+    {
+      "common": "Weeping Chinese Elm",
+      "scientific": "Ulmus parvifolia 'Sempervirens'",
+      "genus": "Ulmus parvifolia 'Sempervirens'"
+    },
+    {
+      "common": "Weeping Double Pink Flowering Cherry",
+      "scientific": "Prunus serrulata 'Double Pink Weeping'",
+      "genus": "Prunus serrulata 'Double Pink Weeping'"
+    },
+    {
+      "common": "WEEPING PAPERBARK",
+      "scientific": "Melaleuca leucadendra",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Weeping Tea Tree",
+      "scientific": "Melaleuca leucadendron",
+      "genus": "Melaleuca "
+    },
+    {
+      "common": "Weeping Willow",
+      "scientific": "Salix babylonica",
+      "genus": "Salix "
+    },
+    {
+      "common": "Weeping Willow",
+      "scientific": "Salix babylonica",
+      "genus": "Salix babylonica"
+    },
+    {
+      "common": "WEEPING WILLOW",
+      "scientific": "Salix babylonica",
+      "genus": "Salix "
+    },
+    {
+      "common": "WESTERN CATALPA",
+      "scientific": "Catalpa speciosa",
+      "genus": "Catalpa "
+    },
+    {
+      "common": "Western Redbud",
+      "scientific": "Cercis occidentalis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Western Redbud",
+      "scientific": "Cercis occidentalis",
+      "genus": "Cercis occidentalis"
+    },
+    {
+      "common": "WESTERN REDBUD",
+      "scientific": "Cercis occidentalis",
+      "genus": "Cercis "
+    },
+    {
+      "common": "Western Red Cedar",
+      "scientific": "Thuja plicata",
+      "genus": "Thuja "
+    },
+    {
+      "common": "Western Red Cedar",
+      "scientific": "Thuja plicata",
+      "genus": "Thuja plicata"
+    },
+    {
+      "common": "W-Fire hydrant within 10",
+      "scientific": "W-Fire hydrant within 10",
+      "genus": "W-Fire "
+    },
+    {
+      "common": "White Alder",
+      "scientific": "Alnus rhombifolia",
+      "genus": "Alnus "
+    },
+    {
+      "common": "White Alder",
+      "scientific": "Alnus rhombifolia",
+      "genus": "Alnus rhombifolia"
+    },
+    {
+      "common": "WHITE ALDER",
+      "scientific": "Alnus rhombifolia",
+      "genus": "Alnus "
+    },
+    {
+      "common": "WHITE ASH",
+      "scientific": "Fraxinus americana",
+      "genus": "Fraxinus "
+    },
+    {
+      "common": "White Champaca",
+      "scientific": "Magnolia x alba",
+      "genus": "Magnolia "
+    },
+    {
+      "common": "White Champaca",
+      "scientific": "Magnolia x alba",
+      "genus": "Magnolia x alba"
+    },
+    {
+      "common": "WHITE CRAPE MYRTLE",
+      "scientific": "Lagerstroemia indica White",
+      "genus": "Lagerstroemia "
+    },
+    {
+      "common": "White escallonia",
+      "scientific": "Escallonia bifida",
+      "genus": "Escallonia "
+    },
+    {
+      "common": "White escallonia",
+      "scientific": "Escallonia bifida",
+      "genus": "Escallonia bifida"
+    },
+    {
+      "common": "White-Flowered Crabapple",
+      "scientific": "Malus x 'Callaway'",
+      "genus": "Malus "
+    },
+    {
+      "common": "White-Flowered Crabapple",
+      "scientific": "Malus x 'Callaway'",
+      "genus": "Malus x 'Callaway'"
+    },
+    {
+      "common": "White flowering bottlebrush",
+      "scientific": "Callistemon salignus",
+      "genus": "Callistemon "
+    },
+    {
+      "common": "White Horsechestnut",
+      "scientific": "Aesculus hippocastanum",
+      "genus": "Aesculus "
+    },
+    {
+      "common": "White Horsechestnut",
+      "scientific": "Aesculus hippocastanum",
+      "genus": "Aesculus hippocastanum"
+    },
+    {
+      "common": "WHITE JACARANDA",
+      "scientific": "Jacaranda mimosifolia Alba",
+      "genus": "Jacaranda "
+    },
+    {
+      "common": "White Mulberry",
+      "scientific": "Morus alba",
+      "genus": "Morus "
+    },
+    {
+      "common": "White Mulberry",
+      "scientific": "Morus alba",
+      "genus": "Morus alba"
+    },
+    {
+      "common": "WHITE MULBERRY",
+      "scientific": "Morus alba",
+      "genus": "Morus "
+    },
+    {
+      "common": "White oak",
+      "scientific": "Quercus alba",
+      "genus": "Quercus "
+    },
+    {
+      "common": "White oak",
+      "scientific": "Quercus alba",
+      "genus": "Quercus alba"
+    },
+    {
+      "common": "White Poplar",
+      "scientific": "Populus alba",
+      "genus": "Populus "
+    },
+    {
+      "common": "White Poplar",
+      "scientific": "Populus alba",
+      "genus": "Populus alba"
+    },
+    {
+      "common": "WHITE POPLAR",
+      "scientific": "Populus alba",
+      "genus": "Populus "
+    },
+    {
+      "common": "WHITE SAPOTE",
+      "scientific": "Casimiroa edulis",
+      "genus": "Casimiroa "
+    },
+    {
+      "common": "Willow",
+      "scientific": "Salix species",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow",
+      "scientific": "Salix spp",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow",
+      "scientific": "Salix spp",
+      "genus": "Salix spp"
+    },
+    {
+      "common": "Willow, Black",
+      "scientific": "Salix nigra",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow, Corkscrew",
+      "scientific": "Salix matsudana",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow, Desert",
+      "scientific": "Chilopsis linearis",
+      "genus": "Chilopsis "
+    },
+    {
+      "common": "Willow, Goat",
+      "scientific": "Salix caprea",
+      "genus": "Salix "
+    },
+    {
+      "common": "WILLOW SPECIES",
+      "scientific": "Salix spp.",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow wattle",
+      "scientific": "Acacia iteaphylla",
+      "genus": "Acacia "
+    },
+    {
+      "common": "Willow wattle",
+      "scientific": "Acacia iteaphylla",
+      "genus": "Acacia iteaphylla"
+    },
+    {
+      "common": "Willow, Weeping",
+      "scientific": "Salix babylonica",
+      "genus": "Salix "
+    },
+    {
+      "common": "Willow, Wilga; Australian",
+      "scientific": "Geijera parviflora",
+      "genus": "Geijera "
+    },
+    {
+      "common": "Wilson Holly Tree",
+      "scientific": "Ilex altaclarensis 'Wilsonii'",
+      "genus": "Ilex "
+    },
+    {
+      "common": "Wilson Holly Tree",
+      "scientific": "Ilex altaclarensis 'Wilsonii'",
+      "genus": "Ilex altaclarensis 'Wilsonii'"
+    },
+    {
+      "common": "Wilson Olive Semi-fruitless",
+      "scientific": "Olea europaea 'Wilsonii'",
+      "genus": "Olea "
+    },
+    {
+      "common": "Wilson Olive Semi-fruitless",
+      "scientific": "Olea europaea 'Wilsonii'",
+      "genus": "Olea europaea 'Wilsonii'"
+    },
+    {
+      "common": "Windmill Palm",
+      "scientific": "Trachycarpus fortunei",
+      "genus": "Trachycarpus "
+    },
+    {
+      "common": "Windmill Palm",
+      "scientific": "Trachycarpus fortunei",
+      "genus": "Trachycarpus fortunei"
+    },
+    {
+      "common": "WINDMILL PALM",
+      "scientific": "Trachycarpus fortunei",
+      "genus": "Trachycarpus "
+    },
+    {
+      "common": "Witch Hazel",
+      "scientific": "Hamamelis virginiana",
+      "genus": "Hamamelis "
+    },
+    {
+      "common": "Woollybutt",
+      "scientific": "Eucalyptus longifolia",
+      "genus": "Eucalyptus longifolia"
+    },
+    {
+      "common": "Xaxim",
+      "scientific": "Dicksonia sellowiana",
+      "genus": "Dicksonia "
+    },
+    {
+      "common": "XYLOSMA",
+      "scientific": "Xylosma congestum",
+      "genus": "Xylosma "
+    },
+    {
+      "common": "Xylosma, Shiny",
+      "scientific": "Xylosma congestum",
+      "genus": "Xylosma "
+    },
+    {
+      "common": "Yarwood Sycamore",
+      "scientific": "Platanus x hispanica 'Yarwood'",
+      "genus": "Platanus "
+    },
+    {
+      "common": "Yarwood Sycamore",
+      "scientific": "Platanus x hispanica 'Yarwood'",
+      "genus": "Platanus x hispanica 'Yarwood'"
+    },
+    {
+      "common": "Yate",
+      "scientific": "Eucalyptus cornuta",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Yate, Bushy",
+      "scientific": "Eucalyptus lehmannii",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Yellow Box",
+      "scientific": "Eucalyptus melliodora",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Yellow Box",
+      "scientific": "Eucalyptus melliodora",
+      "genus": "Eucalyptus melliodora"
+    },
+    {
+      "common": "Yellow conebush",
+      "scientific": "Leucadendron 'Gold Strike'",
+      "genus": "Leucadendron "
+    },
+    {
+      "common": "Yellow conebush",
+      "scientific": "Leucadendron 'Gold Strike'",
+      "genus": "Leucadendron 'Gold Strike'"
+    },
+    {
+      "common": "Yellow-Elder",
+      "scientific": "Tecoma stans",
+      "genus": "Tecoma "
+    },
+    {
+      "common": "Yellow Gum",
+      "scientific": "Eucalyptus leucoxylon mac 'Rosea'",
+      "genus": "Eucalyptus "
+    },
+    {
+      "common": "Yellow Gum",
+      "scientific": "Eucalyptus leucoxylon mac 'Rosea'",
+      "genus": "Eucalyptus leucoxylon mac 'Rosea'"
+    },
+    {
+      "common": "Yellowwood, Long-Leafed",
+      "scientific": "Podocarpus henkelii",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "Yew",
+      "scientific": "Taxus species",
+      "genus": "Taxus "
+    },
+    {
+      "common": "Yew, Pacific",
+      "scientific": "Taxus brevifolia",
+      "genus": "Taxus "
+    },
+    {
+      "common": "Yew Pine",
+      "scientific": "Podocarpus macrophyllus",
+      "genus": "Podocarpus "
+    },
+    {
+      "common": "Yew Pine",
+      "scientific": "Podocarpus macrophyllus",
+      "genus": "Podocarpus macrophyllus"
+    },
+    {
+      "common": "YEW SPECIES",
+      "scientific": "Taxus spp.",
+      "genus": "Taxus "
+    },
+    {
+      "common": "Yoshino Cherry",
+      "scientific": "Prunus x yedoensis",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Yoshino Cherry",
+      "scientific": "Prunus x yedoensis",
+      "genus": "Prunus x yedoensis"
+    },
+    {
+      "common": "YOSHINO CHERRY",
+      "scientific": "Prunus yedoensis",
+      "genus": "Prunus "
+    },
+    {
+      "common": "Yucca",
+      "scientific": "Yucca species",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Yucca",
+      "scientific": "Yucca spp",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Yucca",
+      "scientific": "Yucca spp",
+      "genus": "Yucca spp"
+    },
+    {
+      "common": "Yucca, Curveleaf",
+      "scientific": "Yucca recurvifolia",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Yucca, Moundlily",
+      "scientific": "Yucca gloriosa",
+      "genus": "Yucca "
+    },
+    {
+      "common": "YUCCA SPECIES",
+      "scientific": "Yucca spp.",
+      "genus": "Yucca "
+    },
+    {
+      "common": "Zelkova, Japanese",
+      "scientific": "Zelkova serrata",
+      "genus": "Zelkova "
+    }
+  ]
+}


### PR DESCRIPTION
I added the trees from the database to the data files as `databaseTrees.json`. The changes relate to fixing any issues that came up from doing this.

- Was getting a duplicate key warning and needed to add a filter to ignore duplicate "vacant site" instances 
- Extracted functions `normalizeNames` and `replaceIrregularNames` to handle names with accented characters or other weird names.
- After adding the database trees, the alphabetical sorting broke in the new tree dropdowns. Changed `createTreeSorter` to use [Intl.Collator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator), which allows for more powerful sorting. It handles accented characters, punctuation, and letter case.
<img width="349" alt="Screen Shot 2022-05-02 at 9 49 12 PM" src="https://user-images.githubusercontent.com/6326660/166406722-469c13ee-2e78-46b0-9d6f-823aecafd7bd.png">
