### PR TITLE
tree crashing because of Object.hasOwn in Safari/duckduckgo on mobile

### DIFF
--- a/client/src/pages/Tree/Tree.js
+++ b/client/src/pages/Tree/Tree.js
@@ -72,7 +72,7 @@ export default function Tree({
             isTreeQueryError={isTreeQueryError}
           />
 
-          {scientific && Object.hasOwn(treeImages, scientific) && (
+          {scientific && Object.hasOwnProperty(treeImages, scientific) && (
             <ImageLoad
               src={treeImages[scientific]}
               placeholder="placeholder.jpg"


### PR DESCRIPTION
Tree.js crashing because of Object.hasOwn in Safari/duckduckgo on mobile

changed it to Object.hasOwnProperty and is working now on production already.

Production has this branch checked out but once its merged, I will pull main back to prod