### PR TITLE
patch: Add dev.waterthetrees.com to localhost development

### DIFF
--- a/client/src/api/apiEndpoints.js
+++ b/client/src/api/apiEndpoints.js
@@ -3,7 +3,7 @@ export const env =
     'waterthetrees.com': 'prod',
     'dev.waterthetrees.com': 'dev',
     'blue.waterthetrees.com': 'blue',
-    localhost: 'docker',
+    localhost: 'dev',
   }[window.location.hostname] || 'localserver';
 
 export const url = {


### PR DESCRIPTION
Instead of having to have the db and wtt_server running, you can now just run the wtt_front with `npm run start:dev` and it will connect to dev.waterthetrees.com database and backend wtt_server instead of your local docker version. If you are only working on front end, this is the way to go.

To run it wtt_server and wtt_db locally still, you can run these to connect to your localhost instead of dev.waterthetrees.com.
    "start": "node server/index.js localserver",
    "start:docker": "npm run watch & npm run start:nodemon",
    "start:nodemon": "nodemon server/index.js localserver",