### PR TITLE
fix: display blank string if city is not defined

### DIFF
--- a/client/src/pages/Tree/TreeLinks.js
+++ b/client/src/pages/Tree/TreeLinks.js
@@ -10,11 +10,11 @@ export default function TreeLinks({ currentTreeData }) {
   const links = [
     {
       url: currentTreeData.download,
-      label: `${currentTreeData.city} Data`,
+      label: currentTreeData.city ? `${currentTreeData.city} Data` : `Data`,
     },
     {
       url: currentTreeData.info,
-      label: `${currentTreeData.city} Info`,
+      label: currentTreeData.city ? `${currentTreeData.city} Info` : `Info`,
     },
     {
       url: 'https://standards.opencouncildata.org/#/trees',

--- a/client/src/pages/Tree/TreeLinks.js
+++ b/client/src/pages/Tree/TreeLinks.js
@@ -7,14 +7,16 @@ import { Link, Box } from '@mui/material';
 import Section from '@/components/Section/Section';
 
 export default function TreeLinks({ currentTreeData }) {
+  const { download, info, city, sourceId } = currentTreeData;
+  const sourceName = city || sourceId || '';
   const links = [
     {
-      url: currentTreeData.download,
-      label: currentTreeData.city ? `${currentTreeData.city} Data` : `Data`,
+      url: download,
+      label: `${sourceName} Data`,
     },
     {
-      url: currentTreeData.info,
-      label: currentTreeData.city ? `${currentTreeData.city} Info` : `Info`,
+      url: info,
+      label: `${sourceName} Info`,
     },
     {
       url: 'https://standards.opencouncildata.org/#/trees',


### PR DESCRIPTION
Addresses https://github.com/waterthetrees/wtt_front/issues/323.

In some cases there are download links but cities aren't defined, which causes UI to display "undefined Data", this change will simply show it as "Data"