### PR TITLE
fixed issue 361 useForm

### DIFF
--- a/client/src/pages/NewTree/NewTree.js
+++ b/client/src/pages/NewTree/NewTree.js
@@ -18,7 +18,7 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
   const { nickname, email, name } = user;
 
   /* 
-    tenery used to avoid any errors caused by useForm hook
+    ternary used to avoid any errors caused by useForm hook
     when moving early return statements after hook calls for linting
   */
 

--- a/client/src/pages/NewTree/NewTree.js
+++ b/client/src/pages/NewTree/NewTree.js
@@ -44,7 +44,7 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
   };
 
   const formMethods = useForm({ defaultValues, mode: 'all' });
-  
+
   if (!newTreeState.coords) {
     return null;
   }

--- a/client/src/pages/NewTree/NewTree.js
+++ b/client/src/pages/NewTree/NewTree.js
@@ -12,11 +12,6 @@ import { useNewTree } from './useNewTree';
 
 export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
   const { newTreeState, confirm, cancel } = useNewTree();
-
-  if (!newTreeState.coords) {
-    return null;
-  }
-
   const { user = {} } = useAuth0();
   const { nickname, email, name } = user;
   const defaultValues = {
@@ -31,8 +26,8 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
     state: '',
     zip: '',
     neighborhood: '',
-    lng: newTreeState.coords.lng,
-    lat: newTreeState.coords.lat,
+    lng: newTreeState.coords ? newTreeState.coords?.lng : '',
+    lat: newTreeState.coords ? newTreeState.coords?.lat : '',
     owner: 'public',
     who: '',
     volunteer: nickname || name || email || 'volunteer',
@@ -44,8 +39,12 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
       9999999,
     )}`,
   };
-  // Set mode to "all" to check for errors when fields change or lose focus.
   const formMethods = useForm({ defaultValues, mode: 'all' });
+  if (!newTreeState.coords) {
+    return null;
+  }
+
+  // Set mode to "all" to check for errors when fields change or lose focus.
   const { handleSubmit } = formMethods;
 
   const handleConfirm = (data) => confirm({ ...defaultValues, ...data });

--- a/client/src/pages/NewTree/NewTree.js
+++ b/client/src/pages/NewTree/NewTree.js
@@ -12,8 +12,11 @@ import { useNewTree } from './useNewTree';
 
 export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
   const { newTreeState, confirm, cancel } = useNewTree();
+
   const { user = {} } = useAuth0();
+
   const { nickname, email, name } = user;
+
   const defaultValues = {
     city: '',
     common: '',
@@ -39,7 +42,9 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
       9999999,
     )}`,
   };
+
   const formMethods = useForm({ defaultValues, mode: 'all' });
+  
   if (!newTreeState.coords) {
     return null;
   }

--- a/client/src/pages/NewTree/NewTree.js
+++ b/client/src/pages/NewTree/NewTree.js
@@ -17,6 +17,11 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
 
   const { nickname, email, name } = user;
 
+  /* 
+    tenery used to avoid any errors caused by useForm hook
+    when moving early return statements after hook calls for linting
+  */
+
   const defaultValues = {
     city: '',
     common: '',
@@ -29,8 +34,8 @@ export default function NewTree({ TreeDetailsContainer, drawerWidth }) {
     state: '',
     zip: '',
     neighborhood: '',
-    lng: newTreeState.coords ? newTreeState.coords?.lng : '',
-    lat: newTreeState.coords ? newTreeState.coords?.lat : '',
+    lng: newTreeState.coords ? newTreeState.coords.lng : '',
+    lat: newTreeState.coords ? newTreeState.coords.lat : '',
     owner: 'public',
     who: '',
     volunteer: nickname || name || email || 'volunteer',

--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,7 @@ app.use(compression());
 app.use(morgan('dev'));
 app.use('/', express.static('client/public'));
 app.get('/*', (req, res) => {
-  res.sendFile(path.resolve('../client/public/index.html'), (err) => {
+  res.sendFile(path.resolve(__dirname, '../client/public/index.html'), (err) => {
     if (err) {
       res.status(500).send(err);
     }


### PR DESCRIPTION
#361 
Before:
![image](https://user-images.githubusercontent.com/91238232/199780458-de1a6c19-815e-4454-9387-39d8bbc956ad.png)

Fix
![image](https://user-images.githubusercontent.com/91238232/199780356-aa5138c0-49ad-4989-a0e0-071586543df4.png)

The lint issue was caused by a condition returning early before a hook was called.
What I did was move that condition to the bottom of the hook calls from useAuth0 and useForm. 

Then to make sure there wasn't any issue with key into newTreeState.coords for the lng and lat key for defaultValues. I used a ternary to see if it exists I can key into lng and lat, but if it doesnt it sets it to an empty string. 

This way if it doesnt exists it wont error out and will be set to an empty string. but will still return null after when it doesn't exist. It might not be the most efficient since you're still end up creating defaultValues, but this will remove that error.

I have tested it and it doesn't seem to be causing any errors when placing down a marker and clicking on it and is working the same way as before. I havent actually tried to plant since I don't want to mess with the map.

@zoobot I would love it if you could look at this, since it pertains to the map.
@Tijani-zainab This would also fix #360 as well


