### PR TITLE
Use Geolocation API to center map by current location on load in certain cases

### DIFF
--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -35,9 +35,11 @@ const unsupportedError = (
   </Box>
 );
 
-// If browser supports geolocation, let's check if we have geo permissions and update lat/long if so
+// If browser supports geolocation and there is no hash param on page load,
+// let's check if we have geo permissions and use that to recenter map if so
 const geoPermissionsPromise =
-  'geolocation' in navigator
+  'geolocation' in navigator &&
+  !new URLSearchParams(window.location.hash.slice(1)).get('pos')
     ? navigator.permissions.query({ name: 'geolocation' })
     : Promise.resolve('unsupported');
 
@@ -106,7 +108,7 @@ export default function Map({
   }, [selectionEnabled]);
 
   useEffect(() => {
-    const getGeolocation = async () => {
+    const recenterOnLocation = async () => {
       const result = await geoPermissionsPromise;
       // Will return ['granted', 'prompt', 'denied', 'unsupported']
       if (result.state === 'granted') {
@@ -117,8 +119,9 @@ export default function Map({
         });
       }
     };
+
     if (map) {
-      getGeolocation();
+      recenterOnLocation();
     }
   }, [map]);
 

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -142,6 +142,23 @@ export default function Map({
           url: 'mapbox://waterthetrees.open-trees',
         });
 
+        // If browser supports geolocation, let's check if we have geo permissions and update lat/long if so
+        if ('geolocation' in navigator) {
+          navigator.permissions
+            .query({ name: 'geolocation' })
+            .then(function (result) {
+              // Will return ['granted', 'prompt', 'denied']
+              if (result.state === 'granted') {
+                navigator.geolocation.getCurrentPosition((position) => {
+                  mapboxMap.setCenter([
+                    position.coords.longitude,
+                    position.coords.latitude,
+                  ]);
+                });
+              }
+            });
+        }
+
         onLoad(mapboxMap);
         setIsMapLoaded(true);
 

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -37,11 +37,15 @@ const unsupportedError = (
 
 // If browser supports geolocation and there is no hash param on page load,
 // let's check if we have geo permissions and use that to recenter map if so
-const geoPermissionsPromise =
+let geoPermissionsPromise = Promise.resolve('unsupported');
+if (
   'geolocation' in navigator &&
   !new URLSearchParams(window.location.hash.slice(1)).get('pos')
-    ? navigator.permissions.query({ name: 'geolocation' })
-    : Promise.resolve('unsupported');
+) {
+  geoPermissionsPromise = navigator.permissions.query({ name: 'geolocation' });
+} else if ('geolocation' in navigator) {
+  Promise.resolve('denied');
+}
 
 function createPopupHTML({ common, scientific }) {
   const commonString = common ? `<h4>${common}</h4>` : '';


### PR DESCRIPTION
See https://github.com/waterthetrees/wtt_front/issues/192

This is 
> v0: If they already have location services allowed AND if there's no pos/zoom hash in the url, use Geolocation API to center map

Unfortunately, it appears that checking if a user has already given location permissions is only possible through an async promise. Therefore, the options are either making the map load wait until we can pass in user's geo coords or recentering the map after the mapBox object has been created. 
In my approach, I try to kick off the permissions query asap. Inside a `useEffect` hook, we recenter the map as soon as the permissions query promise resolves and there is a `map` object in state. This is not guaranteed to run before `mapboxMap` kicks off its `load` event.

Assumptions:
* This app only supports modern browsers due to support for the Permissions API:  https://caniuse.com/permissions-api
* This code is only ran client-side so we don't run into any node shenanigans

Manually Tested:
* User does not get prompted for location permissions
* If there is a hash coordinate already present, map will not recenter
* If user does have permissions and there is no existing hash coord, map will load up centered at user's location