### PR TITLE
Only recenter when pressing the Geolocate button

### DIFF
--- a/client/src/pages/UserLocation/GeolocateControl.js
+++ b/client/src/pages/UserLocation/GeolocateControl.js
@@ -42,7 +42,7 @@ export default function GeolocateControl({ map }) {
     if (isTracking && coords && map) {
       map.flyTo({ center: coords });
     }
-  }, [isTracking, coords, map]);
+  }, [isTracking, map]);
 
   const handleClick = () => {
     if (isTracking) {


### PR DESCRIPTION
I was investigating a bug where when location is enabled, no matter where I panned to on the map, I kept being recentered to my current location. 

Example gif:
![RecenterOnLocationUpdate](https://user-images.githubusercontent.com/10445556/209476890-937f6bb6-a190-4a92-8938-08dcef3d304f.gif)

Turns out it is due to the coordinates being changed slightly and the resulting rerender caused by geolocate watch. This can be a slight annoyance in some situations but make the location feature completely unusable in other situations. In SF, I experienced recentering every 2 seconds even when staying still (wi-fi / cell tower geolocation noise?) which made it impossible to interact with trees not in my intermediate area. If this is intentional, I would like to discuss changing this functionality :)

After the change: user location marker will update when coordinates update, but the map will only recenter upon activating geolocate feature by click
(As far as I know, this is not a reported bug but please direct me to the issue if there is an existing related issue)