### PR TITLE
Replace useEffect handling tree selection in MapLayout

### DIFF
--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -6,7 +6,6 @@ import {
   DialogTitle,
   Drawer,
   IconButton,
-  Slide,
   styled,
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
@@ -37,25 +36,23 @@ export default function PanelDrawer({
   onClose,
 }) {
   return (
-    <Slide direction="left" in={open} timeout={500} mountOnEnter unmountOnExit>
-      <StyledDrawer
-        open
-        anchor={anchor}
-        width={width}
-        onClose={onClose}
-        variant="persistent"
-      >
-        <DialogTitle sx={{ py: 1 }}>
-          <Box display="flex" alignItems="center">
-            <Box flexGrow={1}>{title}</Box>
-            <IconButton size="small" onClick={onClose} sx={{ mr: -1.5 }}>
-              <Close />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>{children}</DialogContent>
-        {actions && <DialogActions>{actions}</DialogActions>}
-      </StyledDrawer>
-    </Slide>
+    <StyledDrawer
+      open={open}
+      anchor={anchor}
+      width={width}
+      onClose={onClose}
+      variant="persistent"
+    >
+      <DialogTitle sx={{ py: 1 }}>
+        <Box display="flex" alignItems="center">
+          <Box flexGrow={1}>{title}</Box>
+          <IconButton size="small" onClick={onClose} sx={{ mr: -1.5 }}>
+            <Close />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent dividers>{children}</DialogContent>
+      {actions && <DialogActions>{actions}</DialogActions>}
+    </StyledDrawer>
   );
 }

--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -12,9 +12,7 @@ import { Close } from '@mui/icons-material';
 
 const StyledDrawer = styled(Drawer)(
   ({ width }) => `
-  // Give the background of the container the same color as land on the map, so that it's not
-  // so jarring when the white drawer closes.
-  background: #c5def6;
+  position: absolute;
   width: ${width}px;
   flex-shrink: 0;
 
@@ -36,6 +34,9 @@ export default function PanelDrawer({
   actions,
   onClose,
 }) {
+  if (!open) {
+    return null;
+  }
   return (
     <StyledDrawer
       open={open}

--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -16,6 +16,7 @@ const StyledDrawer = styled(Drawer)(
   position: absolute;
   right: 0;
   width: ${width}px;
+  height: 100vh;
 
   & .MuiDrawer-paper {
     // Add padding at the top to account for the header.

--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -6,6 +6,7 @@ import {
   DialogTitle,
   Drawer,
   IconButton,
+  Slide,
   styled,
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
@@ -13,13 +14,13 @@ import { Close } from '@mui/icons-material';
 const StyledDrawer = styled(Drawer)(
   ({ width }) => `
   position: absolute;
+  right: 0;
   width: ${width}px;
-  flex-shrink: 0;
 
   & .MuiDrawer-paper {
     // Add padding at the top to account for the header.
+    position: relative;
     padding-top: 3.5rem;
-    width: ${width}px;
     box-shadow: -5px 0px 15px -3px rgba(0, 0, 0, 0.15);
   }
 `,
@@ -34,27 +35,26 @@ export default function PanelDrawer({
   actions,
   onClose,
 }) {
-  if (!open) {
-    return null;
-  }
   return (
-    <StyledDrawer
-      open={open}
-      anchor={anchor}
-      width={width}
-      onClose={onClose}
-      variant="persistent"
-    >
-      <DialogTitle sx={{ py: 1 }}>
-        <Box display="flex" alignItems="center">
-          <Box flexGrow={1}>{title}</Box>
-          <IconButton size="small" onClick={onClose} sx={{ mr: -1.5 }}>
-            <Close />
-          </IconButton>
-        </Box>
-      </DialogTitle>
-      <DialogContent dividers>{children}</DialogContent>
-      {actions && <DialogActions>{actions}</DialogActions>}
-    </StyledDrawer>
+    <Slide direction="left" in={open} timeout={500} mountOnEnter unmountOnExit>
+      <StyledDrawer
+        open
+        anchor={anchor}
+        width={width}
+        onClose={onClose}
+        variant="persistent"
+      >
+        <DialogTitle sx={{ py: 1 }}>
+          <Box display="flex" alignItems="center">
+            <Box flexGrow={1}>{title}</Box>
+            <IconButton size="small" onClick={onClose} sx={{ mr: -1.5 }}>
+              <Close />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent dividers>{children}</DialogContent>
+        {actions && <DialogActions>{actions}</DialogActions>}
+      </StyledDrawer>
+    </Slide>
   );
 }

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -202,7 +202,10 @@ export default function Map({
             hashParams.delete('id');
           }
 
-          window.location.hash = decodeURIComponent(hashParams.toString());
+          const newUrl = `${window.location.origin}#${decodeURIComponent(
+            hashParams.toString(),
+          )}`;
+          window.history.replaceState({}, '', newUrl);
         });
 
         // Unlike the click handler above, we want to get mousemove/leave events only for features

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -10,6 +10,7 @@ import { treeHealthUtil } from '@/util/treeHealthUtil';
 import MapboxControlPortal from './MapboxControlPortal';
 import MapLayers from './MapLayers';
 import TreeLayerLegend from './TreeLayerLegend';
+import { getData } from '../../api/apiUtils';
 import './Map.css';
 
 mapboxgl.accessToken = mapboxAccessToken;
@@ -140,6 +141,14 @@ export default function Map({
         mapboxMap.addSource('WTTV', {
           type: 'vector',
           url: 'mapbox://waterthetrees.open-trees',
+        });
+
+        getData('trees').then((response) => {
+          const { lng, lat } = response;
+          map.flyTo({
+            center: [lng, lat],
+            zoom: 15,
+          });
         });
 
         onLoad(mapboxMap);

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -284,20 +284,27 @@ export default function Map({
   );
 }
 
-function flyToTreeAndUpdateCache(mapboxMap, queryClient, setCurrentTreeId) {
+async function flyToTreeAndUpdateCache(
+  mapboxMap,
+  queryClient,
+  setCurrentTreeId,
+) {
   const currentTreeId = new URLSearchParams(window.location.hash.slice(1)).get(
     'id',
   );
   if (currentTreeId != null) {
     const queryKey = ['trees', { id: currentTreeId }];
-    getData({ queryKey }).then((response) => {
+    try {
+      const response = await getData({ queryKey });
       const { lng, lat } = response;
       mapboxMap.flyTo({
         center: [lng, lat],
         zoom: 15,
       });
       queryClient.setQueryData(queryKey, response);
-      setCurrentTreeId(currentTreeId);
-    });
+    } catch {
+      // Do nothing. Since query cache is not updated, request will be retried.
+    }
+    setCurrentTreeId(currentTreeId);
   }
 }

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -288,14 +288,16 @@ function flyToTreeAndUpdateCache(mapboxMap, queryClient, setCurrentTreeId) {
   const currentTreeId = new URLSearchParams(window.location.hash.slice(1)).get(
     'id',
   );
-  const queryKey = ['trees', { id: currentTreeId }];
-  getData({ queryKey }).then((response) => {
-    const { lng, lat } = response;
-    mapboxMap.flyTo({
-      center: [lng, lat],
-      zoom: 15,
+  if (currentTreeId != null) {
+    const queryKey = ['trees', { id: currentTreeId }];
+    getData({ queryKey }).then((response) => {
+      const { lng, lat } = response;
+      mapboxMap.flyTo({
+        center: [lng, lat],
+        zoom: 15,
+      });
+      queryClient.setQueryData(queryKey, response);
+      setCurrentTreeId(currentTreeId);
     });
-    queryClient.setQueryData(queryKey, response);
-    setCurrentTreeId(currentTreeId);
-  });
+  }
 }

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -120,26 +120,6 @@ function MapLayout() {
     setMapSelectionEnabled(!newTreeState.isDragging);
   }, [newTreeState.isDragging]);
 
-  // On initial page load, if there is a tree id in the url as
-  // a hash param, move to that tree on the map.
-  useEffect(() => {
-    if (!map) {
-      return;
-    }
-    const { lng, lat } = currentTreeDataVector || currentTreeDb || {};
-    const currentZoom = map.getZoom();
-    if (lng) {
-      map.flyTo({
-        center: [lng, lat],
-        zoom: currentZoom > DEFAULT_TREE_ZOOM ? currentZoom : DEFAULT_TREE_ZOOM,
-      });
-    } else {
-      hashParams.delete('id');
-      window.location.hash = decodeURIComponent(hashParams.toString());
-      setCurrentTreeId(null);
-    }
-  }, [map, currentTreeData, currentTreeDb, hashParams]);
-
   useEffect(() => {
     if (currentTreeDb) {
       setCurrentTreeData({

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -11,7 +11,6 @@ import ErrorBoundary from '@/components/ErrorBoundary/ErrorBoundary';
 import Tree from '@/pages/Tree/Tree';
 import Map from './Map';
 
-const DEFAULT_TREE_ZOOM = 17;
 const drawerWidth = 350;
 
 const MapContainer = styled('main', {

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -13,36 +13,15 @@ import Map from './Map';
 
 const drawerWidth = 350;
 
-const MapContainer = styled('main', {
-  shouldForwardProp: (prop) => prop.indexOf('drawer') !== 0,
-})(
-  ({
-    theme,
-    drawerEnabled,
-    drawerOpen,
-    drawerWidth, // eslint-disable-line no-shadow
-  }) => ({
-    background: '#c5def6',
-    flexGrow: 1,
-    // We need to use vh here, as height: 100% leaves the map at 0 height.
-    height: '100vh',
-    padding: 0,
-    // Put a position on this element so that the map control groups will move when it changes size.
-    position: 'relative',
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginRight: drawerEnabled ? -drawerWidth : 0,
-    ...(drawerOpen && {
-      transition: theme.transitions.create('margin', {
-        easing: theme.transitions.easing.easeOut,
-        duration: theme.transitions.duration.enteringScreen,
-      }),
-      marginRight: 0,
-    }),
-  }),
-);
+const MapContainer = styled('main')({
+  background: '#c5def6',
+  flexGrow: 1,
+  // We need to use vh here, as height: 100% leaves the map at 0 height.
+  height: '100vh',
+  padding: 0,
+  // Put a position on this element so that the map control groups will move when it changes size.
+  position: 'relative',
+});
 
 function MapLayout() {
   const [currentTreeId, setCurrentTreeId] = useState();
@@ -101,10 +80,6 @@ function MapLayout() {
         />
       </MapContainer>
 
-      {/* We need to render the TreeDetailsContainer Panel even if nothing
-          is selected so that its width is
-          still reserved in the parent Box and therefore the marginRight calculations in
-          Container are correct. */}
       {newTreeState.isPanelOpen ? (
         <NewTree
           TreeDetailsContainer={treeDetailsContainer}

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -87,10 +87,6 @@ function MapLayout() {
         />
       ) : (
         <Tree
-          // Key the TreeDetailsContainer panel on the current tree,
-          // so that when the selection changes, all of the
-          // components get re-rendered with fresh props.
-          key={currentTreeId}
           TreeDetailsContainer={treeDetailsContainer}
           drawerWidth={drawerWidth}
           map={map}


### PR DESCRIPTION
Resolves #397 

Functional change:
* No more map movements when clicking on tree markers

Non-functional changes:
* Reduced lines of code and removed a useEffect that was hard to reason about (it's called with every rerender and it's impossible differentiate initial load from url from subsequent tree selections)
* Performance gains since we're killing the hash params reset and `flyTo` side effects that used to happen on every tree selection 
* Maybe performance gains but definitely jankiness clean up from getting rid of `handleTransitionEnd`, not including the desktop tree details container in the style flow, and not creating a new dom element for every tree

Manually tested loading urls and tree selection on desktop and mobile