### PR TITLE
Update default react query stale time to 5 min

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -33,6 +33,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
+      staleTime: 1000 * 60 * 5, // 5 minutes
     },
   },
 });

--- a/client/src/pages/Map/Map.js
+++ b/client/src/pages/Map/Map.js
@@ -175,18 +175,6 @@ export default function Map({
             };
 
             setCurrentTreeDataVector(currentTree);
-            const queryKeys = ['trees', { id }];
-
-            // Cache the properties from the vector tile as the data for the /trees query that will
-            // be triggered by the setCurrentTreeId() call below.  The Tree will first
-            // get this cached data and then update it when the server response comes back.  But
-            // only do this if there's no cached data already.  If there is, that data is presumably
-            // the latest response from the server, so we don't want to override it with older data
-            // from the vector tile.
-            if (!queryClient.getQueryState(queryKeys)) {
-              queryClient.setQueryData(queryKeys, properties);
-            }
-
             setCurrentTreeId(id);
             hashParams.set('id', id);
             mapboxMap.getCanvas().style.cursor = 'pointer';

--- a/client/src/pages/Map/MapLayout.js
+++ b/client/src/pages/Map/MapLayout.js
@@ -26,7 +26,6 @@ const MapContainer = styled('main')({
 function MapLayout() {
   const [currentTreeId, setCurrentTreeId] = useState();
   const [currentTreeDataVector, setCurrentTreeDataVector] = useState();
-  const [currentTreeData, setCurrentTreeData] = useState();
   const [map, setMap] = useState(null);
   const [mapSelectionEnabled, setMapSelectionEnabled] = useState(true);
   const { newTreeState } = useNewTree();
@@ -53,14 +52,10 @@ function MapLayout() {
     setMapSelectionEnabled(!newTreeState.isDragging);
   }, [newTreeState.isDragging]);
 
-  useEffect(() => {
-    if (currentTreeDb) {
-      setCurrentTreeData({
-        ...currentTreeDb,
-        ...currentTreeDataVector,
-      });
-    }
-  }, [currentTreeDb]);
+  const currentTreeData = {
+    ...currentTreeDataVector,
+    ...currentTreeDb,
+  };
 
   return (
     <Box sx={{ display: 'flex' }}>


### PR DESCRIPTION
The docs _say_ that the cache query keys should be invalidated within 5 min... but from my testing, it doesn't appear that we are caching queries at all.

Which is a shame, since @fwextensions took the time to write this:
https://github.com/waterthetrees/wtt_front/blob/6bca4d3951e2e6fb7d2a8944f8399a52c40c4332/client/src/pages/Map/Map.js#L177-L185

Before:
![image](https://user-images.githubusercontent.com/10445556/213659250-b611c3c2-05a3-4a14-a481-72c59756ca46.png)

After:
![image](https://user-images.githubusercontent.com/10445556/213659449-4ceee17d-6143-4d69-9ba8-371b7d2f8c3f.png)

Only diff is the disappearance of the `State` field: 
![image](https://user-images.githubusercontent.com/10445556/213659560-e6c41de1-da10-411b-82d7-eed916db9088.png)
That's probably something missing from the geojsons for some reason