### PR TITLE
Fixed mobile zoom control

### DIFF
--- a/client/src/pages/Map/Map.css
+++ b/client/src/pages/Map/Map.css
@@ -10,6 +10,16 @@
   top: 6.7rem;
 }
 
+/* hide zoom control from mobile*/
+@media(max-width: 900px) {
+
+  .mapboxgl-ctrl-top-left,
+  .mapboxgl-ctrl-top-right {
+    display: none;
+  }
+}
+
+
 /* an empty button gets inserted in the attribution element for some reason, so hide it */
 .mapboxgl-ctrl-attrib-button {
   display: none;


### PR DESCRIPTION
removed the zoom control buttons for mobile devices since we already pinch the screen to do that.
#411