### PR TITLE
Style only Drawer's Paper subcomponent

### DIFF
--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -6,25 +6,8 @@ import {
   DialogTitle,
   Drawer,
   IconButton,
-  styled,
 } from '@mui/material';
 import { Close } from '@mui/icons-material';
-
-const StyledDrawer = styled(Drawer)(
-  ({ width }) => `
-  position: absolute;
-  left: 0;
-  width: ${width}px;
-  height: 100vh;
-
-  & .MuiDrawer-paper {
-    // Add padding at the top to account for the header.
-    position: relative;
-    padding-top: 3.5rem;
-    box-shadow: -5px 0px 15px -3px rgba(0, 0, 0, 0.15);
-  }
-`,
-);
 
 export default function PanelDrawer({
   children,
@@ -36,10 +19,18 @@ export default function PanelDrawer({
   onClose,
 }) {
   return (
-    <StyledDrawer
+    <Drawer
+      PaperProps={{
+        sx: {
+          position: 'absolute',
+          left: 0,
+          width: `${width}px`,
+          height: '100vh',
+          'padding-top': '3.5rem',
+        },
+      }}
       open={open}
       anchor={anchor}
-      width={open ? width : 0}
       onClose={onClose}
       variant="persistent"
     >
@@ -53,6 +44,6 @@ export default function PanelDrawer({
       </DialogTitle>
       <DialogContent dividers>{children}</DialogContent>
       {actions && <DialogActions>{actions}</DialogActions>}
-    </StyledDrawer>
+    </Drawer>
   );
 }

--- a/client/src/components/PanelDrawer/PanelDrawer.js
+++ b/client/src/components/PanelDrawer/PanelDrawer.js
@@ -27,6 +27,7 @@ export default function PanelDrawer({
           width: `${width}px`,
           height: '100vh',
           'padding-top': '3.5rem',
+          'box-shadow': '5px 0px 15px 3px rgba(0, 0, 0, 0.15)',
         },
       }}
       open={open}


### PR DESCRIPTION
* Better fix for weird invisible drawer shaped container that stays even when drawer is closed and prevents clicking on the map
* Fixed regression in box shadows being on the wrong side after switching drawer from right to left

Before/after changes
https://user-images.githubusercontent.com/10445556/216808240-5fabfe93-2952-430e-8cb8-d79c249b63cb.mp4

Tested selecting trees on desktop. Tested mobile as well just in case, but code shouldn't touch mobile