### PR TITLE
Issue #266: fix ReactDOM.render error

### DIFF
--- a/client/src/components/App/App.css
+++ b/client/src/components/App/App.css
@@ -41,6 +41,7 @@ html {
   line-height: 1.15;
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  font-display: swap;
 }
 
 body {

--- a/client/src/components/Footer/Footer.scss
+++ b/client/src/components/Footer/Footer.scss
@@ -5,6 +5,7 @@
   width: 100%;
   font-family: "Montserrat", sans-serif;
   border-top: rgba(0, 0, 0, 0.472) solid 1px;
+  font-display: swap;
 
   &__content {
     display: flex;

--- a/client/src/components/Header/Header.scss
+++ b/client/src/components/Header/Header.scss
@@ -2,6 +2,7 @@
   font-family: wtt-thin;
   src: local('wtt-thin'),
     url('../../assets/fonts/WTT-THIN.ttf') format('truetype');
+  font-display: swap;
 }
 
 .header {
@@ -25,6 +26,7 @@
     font-size: 1.8rem;
     word-spacing: 0.6rem;
     border: 1px solid #ddd;
+    font-display: swap;
   }
 
   &__font-link:hover {

--- a/client/src/components/Sidebar/Sidebar.scss
+++ b/client/src/components/Sidebar/Sidebar.scss
@@ -10,4 +10,5 @@
 .sidebar-content {
   font-weight: 900;
   font-family: "Roboto Mono", monospace;
+  font-display: swap;
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 // The webpack.resolve.alias setting in webpack.config.js aliases '@' to 'client/src', so that all
 // the import paths can start from there, instead of being relative to the current file.
 import App from '@/components/App/App';
 
-ReactDOM.render(<App />, document.querySelector('.root'));
+const root = createRoot(document.querySelector('.root'));
+root.render(<App />);


### PR DESCRIPTION
### Use createRoot() instead of ReactDOM.render()
React 18 uses createRoot() now instead of ReactDOM.render(). I make the replacement to fix the error.

### Use `font-display: swap` to prevent invisible text
The Lighthouse report shows the error `Ensure text remains visible during webfont load`. The problem is that if you have text being rendered in a certain font, it might be invisible for a moment because the font hasn´t loaded. The fix is to use `font-display: swap` so that the text will be rendered with a system font until the correct font has loaded.