### PR TITLE
test: Bring accessibility up to 100% in Lighthouse check

### DIFF
--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -1,0 +1,20 @@
+name: Build project and run Lighthouse CI
+on: [push]
+jobs:
+  lhci:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - name: npm install production
+        run: |
+          npm install --production
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@10.1.0
+          npm run build
+          lhci autorun --upload.target=temporary-public-storage || echo "LHCI failed!"

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -5,9 +5,9 @@ jobs:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js 18.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
       - name: npm ci

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -4,15 +4,6 @@ jobs:
   lhci:
     name: Lighthouse CI
     runs-on: ubuntu-latest
-    container:
-      image: browserless/chrome
-      options: --user root
-      env:
-        NODE_ENV: development
-      ports:
-        - 80
-      volumes:
-        - /docker_volume
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 18.x
@@ -21,6 +12,11 @@ jobs:
           node-version: 18.x
       - name: npm ci
         run: npm ci
+      - name: Install chrome
+        run: |
+          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          sudo apt-get update
+          sudo apt-get install -y ./google-chrome-stable_current_amd64.deb
       - name: Run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.11.x

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -1,7 +1,7 @@
 name: Build project and run Lighthouse CI
 on: [push]
 jobs:
-  lhci:
+  lighthouse_ci:
     name: Lighthouse CI
     runs-on: ubuntu-latest
     steps:
@@ -11,7 +11,9 @@ jobs:
         with:
           node-version: 18.x
       - name: npm ci
-        run: npm ci
+        run: |
+          npm ci
+          npm run build
       - name: Install chrome
         run: |
           wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
@@ -20,9 +22,6 @@ jobs:
       - name: Run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.11.x
-          npm run build
-          lhci autorun \
-            --only-categories=accessibility,best-practices \
-            --collect.settings.chromeFlags="--no-sandbox --disable-gpu" \
-            --disable-dev-shm-usage \
-            --disable-storage-reset || echo "LHCI failed!"
+          lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -10,11 +10,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18.x
-      - name: npm install
+      - name: npm ci
         run: |
-          npm install
+          npm ci
       - name: run Lighthouse CI
         run: |
+          sudo apt install chromium
           npm install -g @lhci/cli@0.11.x
           npm run build
           lhci autorun --upload.target=temporary-public-storage || echo "LHCI failed!"

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -10,9 +10,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 18.x
-      - name: npm install production
+      - name: npm install
         run: |
-          npm install --production
+          npm install
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.11.x

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -4,6 +4,15 @@ jobs:
   lhci:
     name: Lighthouse CI
     runs-on: ubuntu-latest
+    container:
+      image: browserless/chrome
+      options: --user root
+      env:
+        NODE_ENV: development
+      ports:
+        - 80
+      volumes:
+        - /docker_volume
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js 18.x
@@ -11,11 +20,13 @@ jobs:
         with:
           node-version: 18.x
       - name: npm ci
+        run: npm ci
+      - name: Run Lighthouse CI
         run: |
-          npm ci
-      - name: run Lighthouse CI
-        run: |
-          sudo apt install chromium
           npm install -g @lhci/cli@0.11.x
           npm run build
-          lhci autorun --upload.target=temporary-public-storage || echo "LHCI failed!"
+          lhci autorun \
+            --only-categories=accessibility,best-practices \
+            --collect.settings.chromeFlags="--no-sandbox --disable-gpu" \
+            --disable-dev-shm-usage \
+            --disable-storage-reset || echo "LHCI failed!"

--- a/.github/workflows/lighthouse-ci.yaml
+++ b/.github/workflows/lighthouse-ci.yaml
@@ -15,6 +15,6 @@ jobs:
           npm install --production
       - name: run Lighthouse CI
         run: |
-          npm install -g @lhci/cli@10.1.0
+          npm install -g @lhci/cli@0.11.x
           npm run build
           lhci autorun --upload.target=temporary-public-storage || echo "LHCI failed!"

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -41,6 +41,7 @@ const Header = () => {
           }}
           color="success"
           className="header__btn-menu"
+          title="Menu"
         >
           <MenuRoundedIcon
             sx={{ fontSize: '2.5rem', color: 'black' }}

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -5,7 +5,7 @@
 
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="initial-scale=1.0">
     <meta name="description" content="WATER THE TREES">
     <meta name="author" content="Code for San Francisco">
     <meta name="theme-color" content="#ffffff">

--- a/client/src/pages/NewTree/NewTreeButton.js
+++ b/client/src/pages/NewTree/NewTreeButton.js
@@ -84,6 +84,7 @@ export default function NewTreeButton({ map }) {
         value="Plant"
         selected={isPlanting}
         onChange={handlePlantClick}
+        title="Plant New Tree"
       />
       {map && <NewTreePlantingMarker map={map} onPlantClick={openPanel} />}
     </>

--- a/client/src/pages/UserLocation/GeolocateControl.js
+++ b/client/src/pages/UserLocation/GeolocateControl.js
@@ -60,7 +60,7 @@ export default function GeolocateControl({ map }) {
 
   return (
     <>
-      <IconButton onClick={handleClick} style={{ color: '#333' }}>
+      <IconButton title="Find Your Location" onClick={handleClick} style={{ color: '#333' }}>
         <GeolocateIcon
           isTracking={isTracking}
           isFollowingUser={isFollowingUser}

--- a/client/src/tests/__snapshots__/Header.test.js.snap
+++ b/client/src/tests/__snapshots__/Header.test.js.snap
@@ -390,6 +390,7 @@ exports[`<Header /> spec renders Header correctly 1`] = `
           <button
             class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSuccess MuiIconButton-sizeSmall header__btn-menu emotion-0"
             tabindex="0"
+            title="Menu"
             type="button"
           >
             <svg
@@ -687,6 +688,7 @@ exports[`<Header /> spec renders Header correctly 1`] = `
         <button
           class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorSuccess MuiIconButton-sizeSmall header__btn-menu emotion-0"
           tabindex="0"
+          title="Menu"
           type="button"
         >
           <svg

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  ci: {
+    collect: {
+      startServerCommand: 'npm run start:dev',
+      url: ['http://localhost:3001'],
+    },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', { minScore: 1 }],
+        'categories:best-practices': ['error', { minScore: 1 }],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -3,7 +3,6 @@ module.exports = {
     collect: {
       startServerCommand: 'npm run start:dev',
       url: ['http://localhost:3001'],
-      disableStorageReset: true,
       disableDevShmUsage: true,
       settings: {
         'chromeFlags': '--no-sandbox --headless --disable-gpu',

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -3,6 +3,11 @@ module.exports = {
     collect: {
       startServerCommand: 'npm run start:dev',
       url: ['http://localhost:3001'],
+      disableStorageReset: true,
+      disableDevShmUsage: true,
+      settings: {
+        'chromeFlags': '--no-sandbox --headless --disable-gpu',
+      },
     },
     assert: {
       assertions: {

--- a/server/index.js
+++ b/server/index.js
@@ -38,4 +38,4 @@ app.get('/*', (req, res) => {
 });
 
 const httpServer = http.createServer(app);
-httpServer.listen(port, () => logger.info(`${host}:${port}`));
+httpServer.listen(port, () => logger.info(`listening on ${host}:${port}`));


### PR DESCRIPTION
Fixes #438.

### Abstract
There are two parts to this: fixing the outstanding accessibility issues that Lighthouse reports, and then adding Lighthouse to our CI to ensure that there are no regressions to accessibility in the future.

### Fixing accessibility issues
```
client/src/
    - index.html
    - components/Header/Header.js
    - tests/__snapshots__/Header.test.js.snap
    
    pages/
        - NewTree/NewTreeButton.js
        - UserLocation/GeolocateControl.js
```
There were two types of errors. The first one has to do with some buttons not having [a name which can be seen by screen readers](https://dequeuniversity.com/rules/axe/4.4/button-name). There are multiple ways to fix this, and my solution was to add a `title` attribute to the buttons. The side effect of this is that these buttons now also show tooltip text matching the title. @ri0nardo for reference, these are the buttons changed:

The Menu button:
[Screen recording 2023-03-30 16.55.30.webm](https://user-images.githubusercontent.com/117248915/228990099-caf90d76-8518-4263-b23b-b73b1283f25f.webm)

the Geolocate button:
[Screen recording 2023-03-30 16.54.58.webm](https://user-images.githubusercontent.com/117248915/228989963-4c3aa426-1381-4c0e-879c-bf715d47e05d.webm)

and the `NewTreeButton`:
[Screen recording 2023-03-30 16.56.13.webm](https://user-images.githubusercontent.com/117248915/228990551-ef67ec93-be1d-4a6e-83e1-7f7f42061dcf.webm)

Adding the title required updating the `Header.test.js` snapshot.

The other type of error was that [zoom should be enabled on the map](https://screpy.com/user-scalable-no-and-maximum-scale-errors/).

## Adding Lighthouse to CI
```
lighthouserc.js
.github/workflows/lighthouse-ci.yaml
server/index.js
```

It's great to be able to fix these issues, but the only way you can make the fix last is to add regression testing. I accomplish this by adding Lighthouse to our CI pre-flight. The Lighthouse test will fail if the scores for accessibility or best practices are under 100, so future developers submitting PRs will need to make sure that their UI features meet the standards of Lighthouse. The best, recommended practice for Lighthouse CI is to require 100 from the SEO and PWA scores as well, as performance can give variable results, but fixing those issues is a whole separate issue of work.

To see the results of our Lighthouse runs in pre-flight, I installed the [Lighthouse Github app](https://github.com/apps/lighthouse-ci) and run the action with the [`LHCI_GITHUB_APP_TOKEN`](https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/getting-started.md#github-app-method-recommended) env variable. You should be seeing a status in the pre-flight with the Lighthouse scores and the icon below.

Actually getting the github action to work was quite difficult, mainly because Lighthouse needs to have chrome installed and the different solutions I tried to install Chrome didn't seem to work (using a [docker image](https://hub.docker.com/r/browserless/chrome), using a [github action](https://github.com/treosh/lighthouse-ci-action)) etc. In the end, just manually downloading the chrome .deb debian file worked best, although I fear pulling the .deb by wget could be flaky if it 404s.

I used [nektos/act](https://github.com/nektos/act) to test my github action locally, so I could get faster turn-around and _not_ submit a hundred github commits just to test my github action. That approach has its limits too though, as the action would fail due to a PROTOCOL_TIMEOUT error that is apparently the [#1 most common issue](https://github.com/GoogleChrome/lighthouse/issues/6512) with Lighthouse.

Overall, I like that we can do automated testing with Lighthouse CI, but the tool seems a lot buggier than I would expect from Google devs. It's good enough.