### PR TITLE
fix: Re-enable hot reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,23 @@ nvm use;
 
 ### BUILD AND START JUST FRONT END
 
-1. Command T (on osx)
-
+1. To run with hot reloading (on osx/linux):
 ```shell
 cd wtt_front;
-npm install
+npm install;
+npm run start:dev;
+```
+
+2. if you have problems with that, try running these commands in two windows:
+
+Window 1:
+```shell
 npm run watch;
 ```
 
-2. In a second console tab:
+Window 2:
 ```shell
-npm run start:dev;
+npm run start
 ```
 
 ### BUILD AND START FULL STACK APP [FOLLOW DIRECTIONS HERE](https://github.com/waterthetrees/waterthetrees)

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,7 +1,7 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'npm run start:dev',
+      startServerCommand: 'npm run start',
       url: ['http://localhost:3001'],
       disableDevShmUsage: true,
       settings: {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "start": "node server/index.js localhost",
     "start:docker": "npm run watch & npm run start:nodemon",
     "start:nodemon": "nodemon server/index.js localserver",
-    "start:dev": "node server/index.js development",
+    "start:dev": "webpack serve --env development",
     "test": "jest",
     "test:coverage": "jest --coverage && open-cli coverage/lcov-report/index.html",
     "test:watch": "jest --watch"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,11 +42,6 @@ module.exports = (env) => {
       historyApiFallback: true,
       static: './',
       hot: true,
-      watchOptions: {
-        poll: true,
-        // ignored: /node_modules/,
-        aggregateTimeout: 300,
-      },
     },
     devtool: ifProduction('source-map', 'eval-source-map'),
     // The MapboxLegendControl library triggers this warning when trying to load its source map,
@@ -55,6 +50,12 @@ module.exports = (env) => {
     stats: {
       // Log a build timestamp in the console.
       builtAt: true,
+    },
+    watchOptions: {
+      poll: true,
+      // Exclude big folders or files which don't need to be watched.
+      ignored: ['**/node_modules', '**/vendor', '**/*.json', 'client/src/data/dist', 'data/json'],
+      aggregateTimeout: 300,
     },
     module: {
       rules: removeEmpty([


### PR DESCRIPTION
### Fix watchOptions issue
As mentioned in the slack thread by @mwpark2014, if you tried to run `npm run start:dev` before PR #583, you would see this Webpack error:
```shell
Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'watchOptions'. These properties are valid:
   object { allowedHosts?, bonjour?, client?, compress?, devMiddleware?, headers?, historyApiFallback?, host?, hot?, http2?, https?, ipc?, liveReload?, magicHtml?, onAfterSetupMiddleware?, onBeforeSetupMiddleware?, onListening?, open?, port?, proxy?, server?, setupExitSignals?, setupMiddlewares?, static?, watchFiles?, webSocketServer? }
```
@zoobot's solution to the problem was to change `npm run start:dev` to run a server with `node server/index.js localhost`. This will start a server at localhost:3001 and allow us to develop, but it does not support hot reloading/watching.

This is because the server is not aware of any changes to files, and will just pull the content it saw when it receives a GET request. Imagine if you went to google.com right now. You send a GET request, and the server gives you what it has at the moment. If google released a new version of their site a second after you got your page, the server isn't going to fetch that content unless you send another GET request. In the same way, right now if you want to see your changes in dev you have to refresh the page and send another GET request.

`webpack --serve` does support hot reloading, and will refresh the page when new content is delivered. To fix the issue with `watchOptions`, we simply have to move it up to the global settings of the webpack config. To speed up load times, I exclude some large folders and files from being watched.

### Provide 2 options for running dev server
With my changes there are now 2 ways you could potentially get the dev server running, one with hot reloading and one without. Obviously for development, you want to use the option with hot reloading `npm run start:dev`. However, for CI/CD we can run a more lean dev server and do `npm run start`.