### PR TITLE
Add ability to search for lat/long in map search bar

### DIFF
--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -135,7 +135,7 @@ const isValidFloat = (token) => {
 // Use the first delimiter in VALID_LAT_LNG_DELIMITERS that is found in the input query string
 // to split string into potential lat/lngs
 const splitWithValidDelimiter = (query) => {
-  let coords = query;
+  let coords = [query];
   VALID_LAT_LNG_DELIMITERS.forEach((delimiter) => {
     if (query.includes(delimiter)) {
       coords = query.split(delimiter);

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -10,6 +10,7 @@ const MIN_CHARS_FOR_SEARCH = 2;
 const BASE_MAPBOX_SEARCH_API_URL =
   'https://api.mapbox.com/geocoding/v5/mapbox.places/';
 const SEARCH_QUERY_CACHE_TIME = 1000 * 30; // 30 seconds
+const VALID_LAT_LNG_DELIMITERS = [',', '/', '\\'];
 
 const Search = ({ map }) => {
   const [query, setQuery] = useState('');
@@ -99,8 +100,7 @@ const getMapboxSearchResults = async (query) => {
 
 // Attempt to parse a latitude and longitude from the query
 export const isQueryLatLong = (query) => {
-  // Use commas and forward slashes as possible delimiters
-  const coords = query.includes(',') ? query.split(',') : query.split('/');
+  const coords = splitWithValidDelimiter(query);
   if (coords.length !== 2) {
     return false;
   }
@@ -132,9 +132,22 @@ const isValidFloat = (token) => {
   return true;
 };
 
+// Use the first delimiter in VALID_LAT_LNG_DELIMITERS that is found in the input query string
+// to split string into potential lat/lngs
+const splitWithValidDelimiter = (query) => {
+  let coords = query;
+  VALID_LAT_LNG_DELIMITERS.forEach((delimiter) => {
+    if (query.includes(delimiter)) {
+      coords = query.split(delimiter);
+      return;
+    }
+  });
+  return coords;
+};
+
 // Return a SearchResult that is compatible with the feature data shape from mapbox search API
 const createLatLongSearchResult = (query) => {
-  const coords = query.includes(',') ? query.split(',') : query.split('/');
+  const coords = splitWithValidDelimiter(query);
   const latLng = coords.map((coord) => parseFloat(coord));
 
   return {

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -37,6 +37,7 @@ const Search = ({ map }) => {
     debouncedSetQuery(newQuery);
   };
 
+  // FIXME: This doesn't get triggered when the current selection is selected again from the autocomplete.
   const handleOptionSelect = (e, option) => {
     if (option) {
       map.panTo(option.coords);

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -23,14 +23,13 @@ const Search = ({ map }) => {
   } = useQuery({
     queryKey: query,
     queryFn: () => getMapboxSearchResults(query),
-    enabled: query.length > MIN_CHARS_FOR_SEARCH,
     cacheTime: SEARCH_QUERY_CACHE_TIME,
   });
 
   // Debounce search requests to mitigate churning through our API requests budget
   const debouncedSetQuery = useMemo(
-    (setQuery) => getDebouncedSetQuery(setQuery),
-    [],
+    () => getDebouncedSetQuery(setQuery),
+    [setQuery],
   );
   const handleInputChange = (event) => {
     const newQuery = event.currentTarget.value;
@@ -100,6 +99,9 @@ const getMapboxSearchResponse = async (query) => {
 };
 
 const getMapboxSearchResults = async (query) => {
+  if (query.length <= MIN_CHARS_FOR_SEARCH) {
+    return;
+  }
   const jsonResponse = await getMapboxSearchResponse(query);
   return jsonResponse.features?.map((result) => ({
     label: result.text,

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -99,22 +99,23 @@ const getMapboxSearchResults = async (query) => {
 
 // Attempt to parse a latitude and longitude from the query
 export const isQueryLatLong = (query) => {
-  const tokens = query.split(',');
-  if (tokens.length !== 2) {
+  // Use commas and forward slashes as possible delimiters
+  const coords = query.includes(',') ? query.split(',') : query.split('/');
+  if (coords.length !== 2) {
     return false;
   }
 
-  if (!tokens.every((token) => isValidFloat(token))) {
+  if (!coords.every((coord) => isValidFloat(coord))) {
     return false;
   }
 
-  const latitude = parseFloat(tokens[0]);
+  const latitude = parseFloat(coords[0]);
   // Latitude must be a number between -90 and 90
   if (Math.abs(latitude) > 90) {
     return false;
   }
 
-  const longitude = parseFloat(tokens[1]);
+  const longitude = parseFloat(coords[1]);
   // Longitude must a number between -180 and 180
   if (Math.abs(longitude) > 180) {
     return false;
@@ -133,8 +134,8 @@ const isValidFloat = (token) => {
 
 // Return a SearchResult that is compatible with the feature data shape from mapbox search API
 const createLatLongSearchResult = (query) => {
-  const tokens = query.split(',');
-  const latLng = tokens.map((token) => parseFloat(token));
+  const coords = query.includes(',') ? query.split(',') : query.split('/');
+  const latLng = coords.map((coord) => parseFloat(coord));
 
   return {
     label: query,

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -33,8 +33,8 @@ const Search = ({ map }) => {
       setGeneratedSearchResults([createLatLongSearchResult(newQuery)]);
     } else {
       setGeneratedSearchResults([]);
+      debouncedSetQuery(newQuery);
     }
-    debouncedSetQuery(newQuery);
   };
 
   // FIXME: This doesn't get triggered when the current selection is selected again from the autocomplete.

--- a/client/src/pages/Search/Search.js
+++ b/client/src/pages/Search/Search.js
@@ -29,7 +29,7 @@ const Search = ({ map }) => {
 
   // Debounce search requests to mitigate churning through our API requests budget
   const debouncedSetQuery = useMemo(
-    () => debounce((query) => setQuery(query), AUTOCOMPLETE_DEBOUNCE_TIME),
+    (setQuery) => getDebouncedSetQuery(setQuery),
     [],
   );
   const handleInputChange = (event) => {
@@ -74,6 +74,9 @@ const Search = ({ map }) => {
     </div>
   );
 };
+
+export const getDebouncedSetQuery = (setQuery) =>
+  debounce((query) => setQuery(query), AUTOCOMPLETE_DEBOUNCE_TIME);
 
 const getMapboxSearchResponse = async (query) => {
   const hashParams = new URLSearchParams(window.location.hash.slice(1));

--- a/client/src/tests/Search.test.js
+++ b/client/src/tests/Search.test.js
@@ -1,0 +1,33 @@
+import { isQueryLatLong } from '@/pages/Search/Search';
+
+describe('Test logic in generating search results', () => {
+  it('isQueryLatLong with text input', () => {
+    expect(
+      isQueryLatLong(
+        '825 Milwaukee Ave, Deerfield, Illinois 60015, United States',
+      ),
+    ).toBeFalsy();
+  });
+
+  it('isQueryLatLong with invalid lat/long', () => {
+    expect(isQueryLatLong('')).toBeFalsy();
+  });
+
+  it('isQueryLatLong with valid lat/long', () => {
+    expect(isQueryLatLong('37.77538664389438,-122.3949618700733')).toBeTruthy();
+    expect(isQueryLatLong('37,-122')).toBeTruthy();
+    expect(isQueryLatLong('37.77,-122.39')).toBeTruthy();
+  });
+
+  it('isQueryLatLong with valid lat/long with weird formatting', () => {
+    expect(
+      isQueryLatLong('37.77538664389438, -122.3949618700733'),
+    ).toBeTruthy();
+    expect(
+      isQueryLatLong('  37.77538664389438,  -122.3949618700733  '),
+    ).toBeTruthy();
+    expect(
+      isQueryLatLong(' 37.77538664389438,\n-122.3949618700733 \r '),
+    ).toBeTruthy();
+  });
+});

--- a/client/src/tests/Search.test.js
+++ b/client/src/tests/Search.test.js
@@ -1,4 +1,4 @@
-import { isQueryLatLong } from '@/pages/Search/Search';
+import { getDebouncedSetQuery, isQueryLatLong } from '@/pages/Search/Search';
 
 describe('Test logic in generating search results', () => {
   it('isQueryLatLong with text input', () => {
@@ -42,5 +42,28 @@ describe('Test logic in generating search results', () => {
     expect(
       isQueryLatLong(' 37.77538664389438,\n-122.3949618700733 \r '),
     ).toBeTruthy();
+  });
+});
+
+describe('Test debounce for sending autocomplete search queries', () => {
+  jest.useFakeTimers();
+
+  let mockFunc;
+  beforeEach(() => {
+    mockFunc = jest.fn();
+  });
+
+  it('should debounce search queries', () => {
+    // Tell Jest to mock all timeout functions
+    const debouncedSetQuery = getDebouncedSetQuery(mockFunc);
+
+    for (let i = 0; i < 100; i++) {
+      debouncedSetQuery('test query');
+    }
+
+    // Fast-forward time
+    jest.runAllTimers();
+
+    expect(mockFunc).toBeCalledTimes(1);
   });
 });

--- a/client/src/tests/Search.test.js
+++ b/client/src/tests/Search.test.js
@@ -11,6 +11,12 @@ describe('Test logic in generating search results', () => {
 
   it('isQueryLatLong with invalid lat/long', () => {
     expect(isQueryLatLong('')).toBeFalsy();
+    expect(isQueryLatLong('thirty-seven,one hundred')).toBeFalsy();
+    expect(isQueryLatLong('37.77px, -122px')).toBeFalsy();
+    expect(isQueryLatLong('-122.3949618700733, 37.77538664389438')).toBeFalsy();
+    expect(
+      isQueryLatLong('-122.3949618700733775386643, 37.77538664389438775386643'),
+    ).toBeFalsy();
   });
 
   it('isQueryLatLong with valid lat/long', () => {

--- a/client/src/tests/Search.test.js
+++ b/client/src/tests/Search.test.js
@@ -8,10 +8,13 @@ describe('Test logic in generating search results', () => {
       ),
     ).toBeFalsy();
     expect(isQueryLatLong('thirty-seven,one hundred')).toBeFalsy();
+    expect(isQueryLatLong('thirty')).toBeFalsy();
   });
 
   it('isQueryLatLong with invalid lat/long', () => {
     expect(isQueryLatLong('')).toBeFalsy();
+    expect(isQueryLatLong('41')).toBeFalsy();
+    expect(isQueryLatLong('41,')).toBeFalsy();
     expect(isQueryLatLong('37.77px, -122px')).toBeFalsy();
     expect(isQueryLatLong('37.77--,-122-')).toBeFalsy();
     expect(isQueryLatLong('37.77.12,-122')).toBeFalsy();

--- a/client/src/tests/Search.test.js
+++ b/client/src/tests/Search.test.js
@@ -7,12 +7,15 @@ describe('Test logic in generating search results', () => {
         '825 Milwaukee Ave, Deerfield, Illinois 60015, United States',
       ),
     ).toBeFalsy();
+    expect(isQueryLatLong('thirty-seven,one hundred')).toBeFalsy();
   });
 
   it('isQueryLatLong with invalid lat/long', () => {
     expect(isQueryLatLong('')).toBeFalsy();
-    expect(isQueryLatLong('thirty-seven,one hundred')).toBeFalsy();
     expect(isQueryLatLong('37.77px, -122px')).toBeFalsy();
+    expect(isQueryLatLong('37.77--,-122-')).toBeFalsy();
+    expect(isQueryLatLong('37.77.12,-122')).toBeFalsy();
+    expect(isQueryLatLong('37,-122,37,-122')).toBeFalsy();
     expect(isQueryLatLong('-122.3949618700733, 37.77538664389438')).toBeFalsy();
     expect(
       isQueryLatLong('-122.3949618700733775386643, 37.77538664389438775386643'),
@@ -29,6 +32,7 @@ describe('Test logic in generating search results', () => {
     expect(
       isQueryLatLong('37.77538664389438, -122.3949618700733'),
     ).toBeTruthy();
+    expect(isQueryLatLong('41.03/-99.08')).toBeTruthy();
     expect(
       isQueryLatLong('  37.77538664389438,  -122.3949618700733  '),
     ).toBeTruthy();


### PR DESCRIPTION
Add ability to search for lat/long coordinates in the map search bar!
Doesn't incur mapbox request (unless the person types really slow and requests are sent before the code realizes it's a lat/long query)

![image](https://user-images.githubusercontent.com/10445556/229991430-1e672ea0-5450-4dd4-a0fa-fa816d5d8649.png)
This is how Google does it

![image](https://user-images.githubusercontent.com/10445556/229991490-e8d80c7a-599d-4237-9889-6c2aacc9d5b6.png)
This is how we do it