### PR TITLE
build: fix webpack speed plugin error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { getIfUtils, removeEmpty } = require('webpack-config-utils');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
-const { configure } = require('@testing-library/react');
 
 module.exports = (env) => {
   // Generate config functions for production and analyze env variables
@@ -17,7 +16,7 @@ module.exports = (env) => {
   // Save the config into a variable so that we can wrap it with SpeedMeasurePlugin
   // below if env.analyze is true
   const config = {
-    mode: ifProduction() ? 'production' : 'development',
+    mode: ifProduction('production', 'development'),
     // watch: true,
     entry: './client/src/index.js',
     resolve: {
@@ -125,7 +124,7 @@ module.exports = (env) => {
           './client/src/assets/images/favicons/wtt-christmas-favicon.png',
         template: './client/src/index.html',
         filename: './index.html',
-        minify: ifNotProduction() ? false : true,
+        minify: !ifNotProduction(),
         // add a timestamp that's injected into an HTML comment
         buildTime: new Date().toISOString(),
         title: 'Hot Module Replacement',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,7 +119,7 @@ module.exports = (env) => {
       ]),
     },
     plugins: removeEmpty([
-      ifNotProduction() && new ReactRefreshWebpackPlugin(),
+      ifNotProduction(new ReactRefreshWebpackPlugin()),
       new HtmlWebPackPlugin({
         favicon:
           './client/src/assets/images/favicons/wtt-christmas-favicon.png',


### PR DESCRIPTION
Fixes #666 (scary number!)

The webpack error was being caused by this line:
```
ifNotProduction() && new ReactRefreshWebpackPlugin()
```
I understand the thought process here given that JS allows you to return non-boolean values with the `||` operator, but in this case it doesn't work as expected. If `ifNotProduction()` is false, then the statement short-circuits and returns `false` in the list of plugins. The webpack speed plugin doesn't like this because it's expecting an object, thus the error: `TypeError: Cannot create proxy with a non-object as target or handler`.

The error can be fixed by changing that line to:
```
ifNotProduction(new ReactRefreshWebpackPlugin())
```
If false, then it will return `undefined`, but the encompassing `removeEmpty` call will filter it out of the list. That begs the question though: if `undefined` and `false` are not truthy, why doesn't `removeEmpty` remove both? If you look at [the code for that function](https://github.com/kentcdodds/webpack-config-utils/blob/0d15eee71882de458ed0d0ab5280e42b66e96087/src/remove-empty.js#L47), it _explicitly_ checks for `undefined` and only that. That's weird, but my solution works here.