### PR TITLE
Fix storybook build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -149,7 +149,7 @@ module.exports = (env) => {
   // modifies the original object, so pass it a copy of config so we keep the
   // unmodified original.
   return ifAnalyze(
-    new SpeedMeasurePlugin().wrap({ plugins: config.plugins }),
+    new SpeedMeasurePlugin().wrap(config),
     config,
   );
 };


### PR DESCRIPTION
Storybook uses the 'analyze' webpack config, and some of the key-value data wasn't being pulled into the build. This submission fixes that issue so storybook will build correctly.