### PR TITLE
treelist image fix

### DIFF
--- a/client/src/pages/Tree/TreeImage.js
+++ b/client/src/pages/Tree/TreeImage.js
@@ -2,39 +2,15 @@ import React, { useEffect, useState } from 'react';
 
 import treeImages from '@/data/dist/treeImages.json';
 
+const placeholderPath = './../assets/images/treelist/placeholder.jpg';
+
 export const ImageLoad = React.memo(
-  ({ src, placeholder = 'placeholder.jpg', alt = '' }) => {
+  ({ src, placeholder = placeholderPath, alt = '' }) => {
     const [loading, setLoading] = useState(true);
     const [currentSrc, updateSrc] = useState(placeholder);
 
-    // useEffect(() => {
-    //   if (src !== currentSrc) updateSrc();
-    //   // start loading original image
-    //   const imageToLoad = new Image();
-    //   imageToLoad.src = src;
-    //   imageToLoad.onload = () => {
-    //     // When image is loaded replace the src and set loading to false
-    //     setLoading(false);
-    //     updateSrc(src);
-    //   };
-    // }, [src]);
-
-    // useEffect(() => {
-    //   if (src !== currentSrc) {
-    //     updateSrc(placeholder); // Add this line
-    //   }
-    //   // start loading original image
-    //   const imageToLoad = new Image();
-    //   imageToLoad.src = src;
-    //   imageToLoad.onload = () => {
-    //     // When image is loaded replace the src and set loading to false
-    //     setLoading(false);
-    //     updateSrc(src);
-    //   };
-    // }, [src]);
-
     useEffect(() => {
-      // if (src !== currentSrc) updateSrc();
+      if (src !== currentSrc) updateSrc();
       // start loading original image
       const imageToLoad = new Image();
       imageToLoad.src = src;
@@ -42,11 +18,6 @@ export const ImageLoad = React.memo(
         // When image is loaded replace the src and set loading to false
         setLoading(false);
         updateSrc(src);
-      };
-
-      // Cleanup function to reset currentSrc to placeholder when src changes
-      return () => {
-        updateSrc(placeholder);
       };
     }, [src]);
 
@@ -61,6 +32,7 @@ export const ImageLoad = React.memo(
         placeholder={placeholder}
         alt={alt}
         loading="lazy"
+        onError={(e) => (e.target.style = 'display: "none"')}
       />
     );
   },
@@ -74,12 +46,8 @@ export const setFormatImagePath = (scientific) => {
   if (!scientific || !treeImages[scientific]) return null;
 
   // replace spaces with hyphens for image path using regex
-  const scientificNospaces = scientific
-    .replace(/\s/g, '-')
-    .replace(/'/g, '')
-    .replace(/"/g, '');
+  const scientificNospaces = scientific.toLowerCase().replace(/\s/g, '-');
 
   const imagePath = `../../assets/images/data/${scientificNospaces}.jpg`;
-  // || treeImages[scientific]?.imageURL;
   return imagePath;
 };

--- a/client/src/pages/Tree/TreeImage.js
+++ b/client/src/pages/Tree/TreeImage.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import treeImages from '@/data/dist/treeImages.json';
 
-const placeholderPath = './../assets/images/treelist/placeholder.jpg';
+const placeholderPath = './../assets/images/treelist/placeholder.svg';
 
 export const ImageLoad = React.memo(
   ({ src, placeholder = placeholderPath, alt = '' }) => {

--- a/client/src/pages/TreeList/TreeList.scss
+++ b/client/src/pages/TreeList/TreeList.scss
@@ -8,15 +8,6 @@ $white: white;
 $backgroundColor: white;
 
 $borderRadius: 4px;
-.treecare {
-  font-family: arial, sans-serif;
-  font-size: medium;
-  color: $black;
-  font-weight: 700;
-  text-transform: uppercase;
-  margin: 5px;
-  cursor: pointer;
-}
 
 .treelist {
   $self: &;
@@ -54,7 +45,7 @@ $borderRadius: 4px;
 
   @media screen and (max-width: 480px) {
     &__content {
-      padding: 315px 5px;
+      padding: 273px 5px;
     }
   }
 }

--- a/client/src/pages/TreeList/TreeListCards.js
+++ b/client/src/pages/TreeList/TreeListCards.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router-dom';
 
 import { Tag } from '@/components/Tag/Tag';
 import { ImageLoad, setFormatImagePath } from '@/pages/Tree/TreeImage';
@@ -13,7 +13,7 @@ import './TreeList.scss';
 const HEADING_TEXT = `We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.`;
+first three years to establish their roots. `;
 
 export function getDormancyTagColor(dormancy) {
   switch (dormancy) {
@@ -37,27 +37,23 @@ export const createTreePageRoute = (tree, routeName = 'tree') => {
 };
 
 export default function TreeListCards({ data, selectedDataSourceIndex }) {
+  const { treecare, target } = dataSources[selectedDataSourceIndex];
   return (
     <div className="treelistcards">
+      <div className="treelistcards__header">
+        <h5 className="treelistcards__info">
+          {HEADING_TEXT}
+          <Link
+            to={treecare}
+            target={target}
+            rel={'noopener noreferrer'}
+            className="treelistcards__link"
+          >
+            Learn more about tree care.
+          </Link>
+        </h5>
+      </div>
       <div className="treelistcards__container">
-        <div className="treelistcards__header">
-          <Card>
-            <div className="treelistcards__info">
-              <h3>{HEADING_TEXT}</h3>
-              <div className="treecare">
-                <a
-                  href={dataSources[selectedDataSourceIndex].treecare}
-                  target="_blank"
-                  className="treelistcards__link"
-                  rel="noreferrer"
-                >
-                  Tree Care Program
-                </a>
-              </div>
-            </div>
-          </Card>
-        </div>
-
         {data.map((tree, index) => {
           const { scientific, common, height, deciduousEvergreen } = tree;
           const treeImagePath = setFormatImagePath(scientific);

--- a/client/src/pages/TreeList/TreeListCards.js
+++ b/client/src/pages/TreeList/TreeListCards.js
@@ -61,10 +61,6 @@ export default function TreeListCards({ data, selectedDataSourceIndex }) {
         {data.map((tree, index) => {
           const { scientific, common, height, deciduousEvergreen } = tree;
           const treeImagePath = setFormatImagePath(scientific);
-          const dormancy = deciduousEvergreen?.toLowerCase().replace(/ /g, '-');
-          const tagVariant = getDormancyTagColor(dormancy);
-          const formatCommon = toTitleCase(common);
-          const formatScientific = formatScientificName(scientific);
 
           return (
             <NavLink
@@ -73,24 +69,21 @@ export default function TreeListCards({ data, selectedDataSourceIndex }) {
                 pathname: createTreePageRoute(tree),
               }}
               state={{ tree, selectedDataSourceIndex }}
-              key={`${tree?.scientific}-${index}`}
+              key={`${scientific}-${index}`}
             >
               <Card>
                 {treeImagePath && (
                   <div className="treelistcards__image">
-                    <ImageLoad
-                      src={treeImagePath}
-                      placeholder="placeholder.jpg"
-                    />
+                    <ImageLoad src={treeImagePath} alt={scientific} />
                   </div>
                 )}
                 <div className="treelistcards__info">
-                  <h2>{formatCommon}</h2>
-                  <h4 className="scientific">{formatScientific}</h4>
+                  <h2>{toTitleCase(common)}</h2>
+                  <h4 className="scientific">
+                    {formatScientificName(scientific)}
+                  </h4>
                   <div className="treelistcards__item">{height}</div>
-                  {deciduousEvergreen && (
-                    <Tag variant={tagVariant}>{dormancy}</Tag>
-                  )}
+                  <Dormancy deciduousEvergreen={deciduousEvergreen} />
                 </div>
               </Card>
             </NavLink>
@@ -99,4 +92,28 @@ export default function TreeListCards({ data, selectedDataSourceIndex }) {
       </div>
     </div>
   );
+}
+
+export function Dormancy({ deciduousEvergreen }) {
+  if (
+    !deciduousEvergreen ||
+    deciduousEvergreen === null ||
+    typeof deciduousEvergreen !== 'string'
+  ) {
+    return null;
+  }
+  const dormancyLower = deciduousEvergreen?.replace(/ /g, '-').toLowerCase();
+  // If more than one dormancy, split into array, otherwise create array with one item
+  const dormancyArray = dormancyLower?.includes(',')
+    ? dormancyLower?.split(',')
+    : [dormancyLower];
+
+  return dormancyArray.map((dormancy) => {
+    const tagVariant = getDormancyTagColor(dormancy);
+    return (
+      <Tag key={tagVariant} variant={tagVariant}>
+        {dormancy}
+      </Tag>
+    );
+  });
 }

--- a/client/src/pages/TreeList/dataArrays.js
+++ b/client/src/pages/TreeList/dataArrays.js
@@ -25,6 +25,7 @@ const dataColumns = [
   },
 ];
 
+// TODO rename this to treelists so it doesn't get confused with sources
 export const dataSources = [
   {
     name: 'Native California Trees',
@@ -32,7 +33,8 @@ export const dataSources = [
     columns: dataColumns.slice(0, 4),
     url: 'https://calscape.org/loc-California/cat-Trees/ord-popular?srchcr=sc60ef7918b1949',
     thanks: '©calscape.org',
-    treecare: 'https://vimeo.com/416031708#t=5m35s',
+    treecare: '/treecare',
+    target: '_self',
   },
   {
     name: 'Food Trees',
@@ -40,7 +42,8 @@ export const dataSources = [
     columns: dataColumns.slice(0, 2),
     url: 'https://fallingfruit.org',
     thanks: '©FallingFruit.org',
-    treecare: 'https://vimeo.com/416031708#t=5m35s',
+    treecare: '/treecare',
+    target: '_self',
   },
   {
     name: 'San Francisco Street Trees',
@@ -49,5 +52,6 @@ export const dataSources = [
     url: 'https://www.fuf.net/',
     thanks: '©fuf.net',
     treecare: 'https://www.friendsoftheurbanforest.org/tree-care',
+    target: '_blank',
   },
 ];

--- a/client/src/tests/TreeImage.test.js
+++ b/client/src/tests/TreeImage.test.js
@@ -65,7 +65,7 @@ describe('ImageLoad', () => {
 describe('setFormatImagePath', () => {
   it('returns the correct image path when the scientific name is provided and exists in treeImages', () => {
     const scientificName = 'Quercus alba';
-    const expectedImagePath = '../../assets/images/data/Quercus-alba.jpg';
+    const expectedImagePath = '../../assets/images/data/quercus-alba.jpg';
     const result = setFormatImagePath(scientificName);
 
     expect(result).toBe(expectedImagePath);

--- a/client/src/tests/TreeListCards.test.js
+++ b/client/src/tests/TreeListCards.test.js
@@ -1,8 +1,12 @@
-import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
-import TreeListCards from '@/pages/TreeList/TreeListCards';
+import TreeListCards, {
+  Dormancy,
+  getDormancyTagColor,
+} from '@/pages/TreeList/TreeListCards';
 import { dataSources } from '@/pages/TreeList/dataArrays';
 
 /**
@@ -10,8 +14,28 @@ import { dataSources } from '@/pages/TreeList/dataArrays';
  * are by definition very brittle. If the changes are related to your changes
  * and look expected, update these snapshots with `npm test -- -u`
  */
+const mockData = [
+  {
+    scientific: 'Quercus robur',
+    common: 'English Oak',
+    height: '20-30 feet',
+    deciduousEvergreen: 'deciduous',
+  },
+  {
+    scientific: 'Picea abies',
+    common: 'Norway Spruce',
+    height: '40-60 feet',
+    deciduousEvergreen: 'evergreen',
+  },
+];
 
-describe('<TreeListCards /> spec', () => {
+const mockDataSources = [
+  {
+    treecare: 'https://vimeo.com/416031708#t=5m35s',
+  },
+];
+
+describe('TreeListCards component', () => {
   it('renders TreeListCards correctly', () => {
     const { data } = dataSources[0];
     const filteredData = data.slice(0, 2);
@@ -22,5 +46,122 @@ describe('<TreeListCards /> spec', () => {
       </Router>,
     );
     expect(treeListCards).toMatchSnapshot();
+  });
+
+  test('renders cards correctly', () => {
+    render(
+      <Router>
+        <TreeListCards
+          data={mockData}
+          selectedDataSourceIndex={0}
+          dataSources={mockDataSources}
+        />
+      </Router>,
+    );
+
+    // Check header card
+    expect(screen.getByText(/we encourage you to plant/i)).toBeInTheDocument();
+    expect(screen.getByText(/tree care program/i)).toHaveAttribute(
+      'href',
+      'https://vimeo.com/416031708#t=5m35s',
+    );
+
+    // Check tree cards
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(3); // 2 tree cards + 1 Tree Care Program link
+    expect(links[1]).toHaveAttribute('href', '/tree/quercus-robur');
+    expect(links[2]).toHaveAttribute('href', '/tree/picea-abies');
+
+    expect(screen.getByText('English Oak')).toBeInTheDocument();
+    expect(screen.getByText('Norway Spruce')).toBeInTheDocument();
+    expect(screen.getByText('20-30 feet')).toBeInTheDocument();
+    expect(screen.getByText('40-60 feet')).toBeInTheDocument();
+    expect(screen.getByText(/deciduous/i)).toBeInTheDocument();
+    expect(screen.getByText(/evergreen/i)).toBeInTheDocument();
+  });
+
+  test('handles missing tree data gracefully', () => {
+    const incompleteData = [
+      {
+        scientific: 'Quercus robur',
+      },
+    ];
+
+    render(
+      <Router>
+        <TreeListCards
+          data={incompleteData}
+          selectedDataSourceIndex={0}
+          dataSources={mockDataSources}
+        />
+      </Router>,
+    );
+
+    expect(screen.getByText(/we encourage you to plant/i)).toBeInTheDocument();
+    expect(screen.getByText(/tree care program/i)).toHaveAttribute(
+      'href',
+      'https://vimeo.com/416031708#t=5m35s',
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2); // 1 tree card + 1 Tree Care Program link
+    expect(links[1]).toHaveAttribute('href', '/tree/quercus-robur');
+  });
+});
+
+describe('Dormancy component', () => {
+  test('renders nothing if no valid string is provided', () => {
+    render(<Dormancy deciduousEvergreen={null} />);
+    expect(screen.queryByRole('tag')).not.toBeInTheDocument();
+
+    render(<Dormancy deciduousEvergreen={123} />);
+    expect(screen.queryByRole('tag')).not.toBeInTheDocument();
+
+    render(<Dormancy />);
+    expect(screen.queryByRole('tag')).not.toBeInTheDocument();
+  });
+
+  test('renders single dormancy tag', () => {
+    render(<Dormancy deciduousEvergreen="Evergreen" />);
+    const tag = screen.getByText('evergreen');
+    expect(tag).toBeInTheDocument();
+  });
+
+  test('renders multiple dormancy tags', () => {
+    render(<Dormancy deciduousEvergreen="Deciduous,Winter Deciduous" />);
+    const deciduousTag = screen.getByText('deciduous');
+    const evergreenTag = screen.getByText('winter-deciduous');
+    expect(deciduousTag).toBeInTheDocument();
+    expect(evergreenTag).toBeInTheDocument();
+  });
+});
+
+describe('getDormancyTagColor', () => {
+  it('returns green for evergreen', () => {
+    expect(getDormancyTagColor('evergreen')).toBe('green');
+  });
+
+  it('returns brown for deciduous', () => {
+    expect(getDormancyTagColor('deciduous')).toBe('brown');
+  });
+
+  it('returns blue for winter-deciduous', () => {
+    expect(getDormancyTagColor('winter-deciduous')).toBe('blue');
+  });
+
+  it('returns brown for summer-deciduous', () => {
+    expect(getDormancyTagColor('summer-deciduous')).toBe('brown');
+  });
+
+  it('returns brown for summer-semi-deciduous', () => {
+    expect(getDormancyTagColor('summer-semi-deciduous')).toBe('brown');
+  });
+
+  it('returns black for unknown dormancy', () => {
+    expect(getDormancyTagColor('unknown')).toBe('black');
+  });
+
+  it('returns black for no dormancy provided', () => {
+    expect(getDormancyTagColor()).toBe('black');
   });
 });

--- a/client/src/tests/TreeListCards.test.js
+++ b/client/src/tests/TreeListCards.test.js
@@ -31,7 +31,7 @@ const mockData = [
 
 const mockDataSources = [
   {
-    treecare: 'https://vimeo.com/416031708#t=5m35s',
+    treecare: '/treecare',
   },
 ];
 
@@ -61,10 +61,7 @@ describe('TreeListCards component', () => {
 
     // Check header card
     expect(screen.getByText(/we encourage you to plant/i)).toBeInTheDocument();
-    expect(screen.getByText(/tree care program/i)).toHaveAttribute(
-      'href',
-      'https://vimeo.com/416031708#t=5m35s',
-    );
+    expect(screen.getByText(/tree care/i)).toHaveAttribute('href', '/treecare');
 
     // Check tree cards
     const links = screen.getAllByRole('link');
@@ -98,13 +95,10 @@ describe('TreeListCards component', () => {
     );
 
     expect(screen.getByText(/we encourage you to plant/i)).toBeInTheDocument();
-    expect(screen.getByText(/tree care program/i)).toHaveAttribute(
-      'href',
-      'https://vimeo.com/416031708#t=5m35s',
-    );
+    expect(screen.getByText(/tree care/i)).toHaveAttribute('href', '/treecare');
 
     const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(2); // 1 tree card + 1 Tree Care Program link
+    expect(links).toHaveLength(2); // 1 tree info header + 1 Tree Care link
     expect(links[1]).toHaveAttribute('href', '/tree/quercus-robur');
   });
 });

--- a/client/src/tests/__snapshots__/Tree.test.js.snap
+++ b/client/src/tests/__snapshots__/Tree.test.js.snap
@@ -882,7 +882,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-15:focus::-ms-input-
               alt=""
               loading="lazy"
               placeholder="placeholder.jpg"
-              src="placeholder.jpg"
               style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
             />
             <div
@@ -2452,7 +2451,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-15:focus::-ms-input-
             alt=""
             loading="lazy"
             placeholder="placeholder.jpg"
-            src="placeholder.jpg"
             style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
           />
           <div
@@ -4160,7 +4158,6 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-17:focus::-ms-input-
               alt=""
               loading="lazy"
               placeholder="placeholder.jpg"
-              src="placeholder.jpg"
               style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
             />
             <div

--- a/client/src/tests/__snapshots__/TreeImage.test.js.snap
+++ b/client/src/tests/__snapshots__/TreeImage.test.js.snap
@@ -6,7 +6,6 @@ exports[`ImageLoad Renders the ImageLoad component correctly 1`] = `
     alt="Example image"
     loading="lazy"
     placeholder="https://example.com/placeholder.jpg"
-    src="https://example.com/placeholder.jpg"
     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
   />
 </div>

--- a/client/src/tests/__snapshots__/TreeList.test.js.snap
+++ b/client/src/tests/__snapshots__/TreeList.test.js.snap
@@ -764,10 +764,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Acer buergerianum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -811,10 +810,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Acer circinatum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -894,10 +892,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus californica"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -941,10 +938,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus hippocastanum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -988,10 +984,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus x carnea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1035,10 +1030,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Agonis flexuosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1118,10 +1112,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Angophora costata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1201,10 +1194,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Archontophoenix cunninghamiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1248,10 +1240,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Banksia integrifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1295,10 +1286,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brachychiton acerifolius"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1342,10 +1332,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brachychiton populneus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1389,10 +1378,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brahea clara"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1436,10 +1424,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brahea edulis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1483,10 +1470,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Butia odorata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1530,10 +1516,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Callistemon citrinus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1577,10 +1562,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Callistemon viminalis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1624,10 +1608,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cassia leptophylla"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1743,10 +1726,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Ceanothus thyrsiflorus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1790,10 +1772,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cedrela fissilis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1837,10 +1818,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Ceiba speciosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1884,10 +1864,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Celtis sinensis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1931,10 +1910,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cordyline australis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1978,10 +1956,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corylus colurna"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2025,10 +2002,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corymbia citriodora"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2072,10 +2048,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corymbia ficifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2155,10 +2130,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Crataegus phaenopyrum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2202,10 +2176,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Crataegus x lavallei"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2249,10 +2222,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Elaeocarpus decipiens"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2296,10 +2268,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eriobotrya deflexa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2379,10 +2350,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eucalyptus nicholii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2426,10 +2396,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eucalyptus polyanthemos"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2473,10 +2442,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Garrya elliptica"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2520,10 +2488,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Geijera parviflora"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2603,10 +2570,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Heteromeles arbutifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2650,10 +2616,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Howea forsteriana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2697,10 +2662,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Hymenosporum flavum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2744,10 +2708,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Jacaranda mimosifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2791,10 +2754,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Koelreuteria bipinnata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2838,10 +2800,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Koelreuteria elegans ssp. formosana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2885,10 +2846,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lagunaria patersonii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2968,10 +2928,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Liriodendron tulipifera"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3015,10 +2974,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lophostemon confertus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3062,10 +3020,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lyonothamnus floribundus asplenifolius"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3145,10 +3102,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Magnolia doltsopa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3300,10 +3256,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca ericifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3347,10 +3302,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca linariifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3394,10 +3348,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca quinquenervia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3441,10 +3394,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca squamophloia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3488,10 +3440,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca styphelioides"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3571,10 +3522,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Metrosideros excelsa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3654,10 +3604,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Olea europaea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3701,10 +3650,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Parajubaea sunkha"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3748,10 +3696,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Parajubaea torallyi"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3903,10 +3850,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Pittosporum undulatum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4058,10 +4004,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Prunus ilicifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4105,10 +4050,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Prunus lyonii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4188,10 +4132,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Pyrus kawakamii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4235,10 +4178,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus agrifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4282,10 +4224,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus chyrsolepis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4329,10 +4270,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus coccinea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4376,10 +4316,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus engelmannii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4459,10 +4398,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus hypoleucoides"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4506,10 +4444,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus ilex"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4553,10 +4490,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus phellos"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4600,10 +4536,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus rugosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4647,10 +4582,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus suber"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4694,10 +4628,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus tomentella"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4741,10 +4674,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus virginiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4788,10 +4720,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus wislizeni"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4835,10 +4766,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quillaja saponaria"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4918,10 +4848,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Sambucus cerulea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4965,10 +4894,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Syagrus romanzoffiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5012,10 +4940,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Tilia tomentosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5095,10 +5022,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Tristaniopsis laurina"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5322,10 +5248,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Washingtonia robusta"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5692,10 +5617,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Acer buergerianum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5739,10 +5663,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Acer circinatum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5822,10 +5745,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus californica"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5869,10 +5791,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus hippocastanum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5916,10 +5837,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Aesculus x carnea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5963,10 +5883,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Agonis flexuosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6046,10 +5965,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Angophora costata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6129,10 +6047,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Archontophoenix cunninghamiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6176,10 +6093,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Banksia integrifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6223,10 +6139,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brachychiton acerifolius"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6270,10 +6185,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brachychiton populneus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6317,10 +6231,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brahea clara"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6364,10 +6277,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Brahea edulis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6411,10 +6323,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Butia odorata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6458,10 +6369,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Callistemon citrinus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6505,10 +6415,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Callistemon viminalis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6552,10 +6461,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cassia leptophylla"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6671,10 +6579,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Ceanothus thyrsiflorus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6718,10 +6625,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cedrela fissilis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6765,10 +6671,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Ceiba speciosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6812,10 +6717,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Celtis sinensis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6859,10 +6763,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Cordyline australis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6906,10 +6809,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corylus colurna"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6953,10 +6855,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corymbia citriodora"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7000,10 +6901,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Corymbia ficifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7083,10 +6983,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Crataegus phaenopyrum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7130,10 +7029,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Crataegus x lavallei"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7177,10 +7075,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Elaeocarpus decipiens"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7224,10 +7121,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eriobotrya deflexa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7307,10 +7203,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eucalyptus nicholii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7354,10 +7249,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Eucalyptus polyanthemos"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7401,10 +7295,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Garrya elliptica"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7448,10 +7341,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Geijera parviflora"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7531,10 +7423,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Heteromeles arbutifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7578,10 +7469,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Howea forsteriana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7625,10 +7515,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Hymenosporum flavum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7672,10 +7561,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Jacaranda mimosifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7719,10 +7607,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Koelreuteria bipinnata"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7766,10 +7653,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Koelreuteria elegans ssp. formosana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7813,10 +7699,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lagunaria patersonii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7896,10 +7781,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Liriodendron tulipifera"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7943,10 +7827,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lophostemon confertus"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7990,10 +7873,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Lyonothamnus floribundus asplenifolius"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8073,10 +7955,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Magnolia doltsopa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8228,10 +8109,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca ericifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8275,10 +8155,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca linariifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8322,10 +8201,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca quinquenervia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8369,10 +8247,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca squamophloia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8416,10 +8293,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Melaleuca styphelioides"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8499,10 +8375,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Metrosideros excelsa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8582,10 +8457,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Olea europaea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8629,10 +8503,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Parajubaea sunkha"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8676,10 +8549,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Parajubaea torallyi"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8831,10 +8703,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Pittosporum undulatum"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8986,10 +8857,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Prunus ilicifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9033,10 +8903,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Prunus lyonii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9116,10 +8985,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Pyrus kawakamii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9163,10 +9031,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus agrifolia"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9210,10 +9077,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus chyrsolepis"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9257,10 +9123,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus coccinea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9304,10 +9169,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus engelmannii"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9387,10 +9251,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus hypoleucoides"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9434,10 +9297,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus ilex"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9481,10 +9343,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus phellos"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9528,10 +9389,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus rugosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9575,10 +9435,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus suber"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9622,10 +9481,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus tomentella"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9669,10 +9527,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus virginiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9716,10 +9573,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quercus wislizeni"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9763,10 +9619,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Quillaja saponaria"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9846,10 +9701,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Sambucus cerulea"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9893,10 +9747,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Syagrus romanzoffiana"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9940,10 +9793,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Tilia tomentosa"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -10023,10 +9875,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Tristaniopsis laurina"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -10250,10 +10101,9 @@ first three years to establish their roots.
                     class="treelistcards__image"
                   >
                     <img
-                      alt=""
+                      alt="Washingtonia robusta"
                       loading="lazy"
-                      placeholder="placeholder.jpg"
-                      src="placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.jpg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -11071,10 +10921,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Acer buergerianum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11118,10 +10967,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Acer circinatum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11201,10 +11049,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Aesculus californica"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11248,10 +11095,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Aesculus hippocastanum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11295,10 +11141,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Aesculus x carnea"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11342,10 +11187,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Agonis flexuosa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11425,10 +11269,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Angophora costata"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11508,10 +11351,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Archontophoenix cunninghamiana"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11555,10 +11397,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Banksia integrifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11602,10 +11443,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Brachychiton acerifolius"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11649,10 +11489,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Brachychiton populneus"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11696,10 +11535,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Brahea clara"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11743,10 +11581,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Brahea edulis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11790,10 +11627,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Butia odorata"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11837,10 +11673,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Callistemon citrinus"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11884,10 +11719,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Callistemon viminalis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11931,10 +11765,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Cassia leptophylla"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12050,10 +11883,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Ceanothus thyrsiflorus"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12097,10 +11929,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Cedrela fissilis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12144,10 +11975,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Ceiba speciosa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12191,10 +12021,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Celtis sinensis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12238,10 +12067,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Cordyline australis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12285,10 +12113,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Corylus colurna"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12332,10 +12159,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Corymbia citriodora"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12379,10 +12205,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Corymbia ficifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12462,10 +12287,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Crataegus phaenopyrum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12509,10 +12333,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Crataegus x lavallei"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12556,10 +12379,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Elaeocarpus decipiens"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12603,10 +12425,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Eriobotrya deflexa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12686,10 +12507,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Eucalyptus nicholii"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12733,10 +12553,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Eucalyptus polyanthemos"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12780,10 +12599,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Garrya elliptica"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12827,10 +12645,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Geijera parviflora"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12910,10 +12727,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Heteromeles arbutifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12957,10 +12773,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Howea forsteriana"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13004,10 +12819,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Hymenosporum flavum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13051,10 +12865,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Jacaranda mimosifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13098,10 +12911,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Koelreuteria bipinnata"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13145,10 +12957,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Koelreuteria elegans ssp. formosana"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13192,10 +13003,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Lagunaria patersonii"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13275,10 +13085,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Liriodendron tulipifera"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13322,10 +13131,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Lophostemon confertus"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13369,10 +13177,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Lyonothamnus floribundus asplenifolius"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13452,10 +13259,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Magnolia doltsopa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13607,10 +13413,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Melaleuca ericifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13654,10 +13459,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Melaleuca linariifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13701,10 +13505,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Melaleuca quinquenervia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13748,10 +13551,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Melaleuca squamophloia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13795,10 +13597,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Melaleuca styphelioides"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13878,10 +13679,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Metrosideros excelsa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13961,10 +13761,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Olea europaea"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14008,10 +13807,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Parajubaea sunkha"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14055,10 +13853,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Parajubaea torallyi"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14210,10 +14007,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Pittosporum undulatum"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14365,10 +14161,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Prunus ilicifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14412,10 +14207,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Prunus lyonii"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14495,10 +14289,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Pyrus kawakamii"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14542,10 +14335,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus agrifolia"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14589,10 +14381,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus chyrsolepis"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14636,10 +14427,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus coccinea"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14683,10 +14473,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus engelmannii"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14766,10 +14555,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus hypoleucoides"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14813,10 +14601,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus ilex"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14860,10 +14647,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus phellos"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14907,10 +14693,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus rugosa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14954,10 +14739,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus suber"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15001,10 +14785,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus tomentella"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15048,10 +14831,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus virginiana"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15095,10 +14877,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quercus wislizeni"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15142,10 +14923,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Quillaja saponaria"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15225,10 +15005,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Sambucus cerulea"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15272,10 +15051,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Syagrus romanzoffiana"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15319,10 +15097,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Tilia tomentosa"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15402,10 +15179,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Tristaniopsis laurina"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15629,10 +15405,9 @@ first three years to establish their roots.
                   class="treelistcards__image"
                 >
                   <img
-                    alt=""
+                    alt="Washingtonia robusta"
                     loading="lazy"
-                    placeholder="placeholder.jpg"
-                    src="placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.jpg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>

--- a/client/src/tests/__snapshots__/TreeList.test.js.snap
+++ b/client/src/tests/__snapshots__/TreeList.test.js.snap
@@ -719,39 +719,28 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
             class="treelistcards"
           >
             <div
-              class="treelistcards__container"
+              class="treelistcards__header"
             >
-              <div
-                class="treelistcards__header"
+              <h5
+                class="treelistcards__info"
               >
-                <div
-                  class="card"
-                  data-testid="card"
-                >
-                  <div
-                    class="treelistcards__info"
-                  >
-                    <h3>
-                      We encourage you to plant medium and larger-sized trees, as they
+                We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.
-                    </h3>
-                    <div
-                      class="treecare"
-                    >
-                      <a
-                        class="treelistcards__link"
-                        href="https://www.friendsoftheurbanforest.org/tree-care"
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Tree Care Program
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
+first three years to establish their roots. 
+                <a
+                  class="treelistcards__link"
+                  href="https://www.friendsoftheurbanforest.org/tree-care"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about tree care.
+                </a>
+              </h5>
+            </div>
+            <div
+              class="treelistcards__container"
+            >
               <a
                 class="treelistcards__link"
                 href="/tree/acer-buergerianum"
@@ -766,7 +755,7 @@ first three years to establish their roots.
                     <img
                       alt="Acer buergerianum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -812,7 +801,7 @@ first three years to establish their roots.
                     <img
                       alt="Acer circinatum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -894,7 +883,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus californica"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -940,7 +929,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus hippocastanum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -986,7 +975,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus x carnea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1032,7 +1021,7 @@ first three years to establish their roots.
                     <img
                       alt="Agonis flexuosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1114,7 +1103,7 @@ first three years to establish their roots.
                     <img
                       alt="Angophora costata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1196,7 +1185,7 @@ first three years to establish their roots.
                     <img
                       alt="Archontophoenix cunninghamiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1242,7 +1231,7 @@ first three years to establish their roots.
                     <img
                       alt="Banksia integrifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1288,7 +1277,7 @@ first three years to establish their roots.
                     <img
                       alt="Brachychiton acerifolius"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1334,7 +1323,7 @@ first three years to establish their roots.
                     <img
                       alt="Brachychiton populneus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1380,7 +1369,7 @@ first three years to establish their roots.
                     <img
                       alt="Brahea clara"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1426,7 +1415,7 @@ first three years to establish their roots.
                     <img
                       alt="Brahea edulis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1472,7 +1461,7 @@ first three years to establish their roots.
                     <img
                       alt="Butia odorata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1518,7 +1507,7 @@ first three years to establish their roots.
                     <img
                       alt="Callistemon citrinus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1564,7 +1553,7 @@ first three years to establish their roots.
                     <img
                       alt="Callistemon viminalis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1610,7 +1599,7 @@ first three years to establish their roots.
                     <img
                       alt="Cassia leptophylla"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1728,7 +1717,7 @@ first three years to establish their roots.
                     <img
                       alt="Ceanothus thyrsiflorus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1774,7 +1763,7 @@ first three years to establish their roots.
                     <img
                       alt="Cedrela fissilis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1820,7 +1809,7 @@ first three years to establish their roots.
                     <img
                       alt="Ceiba speciosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1866,7 +1855,7 @@ first three years to establish their roots.
                     <img
                       alt="Celtis sinensis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1912,7 +1901,7 @@ first three years to establish their roots.
                     <img
                       alt="Cordyline australis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -1958,7 +1947,7 @@ first three years to establish their roots.
                     <img
                       alt="Corylus colurna"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2004,7 +1993,7 @@ first three years to establish their roots.
                     <img
                       alt="Corymbia citriodora"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2050,7 +2039,7 @@ first three years to establish their roots.
                     <img
                       alt="Corymbia ficifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2132,7 +2121,7 @@ first three years to establish their roots.
                     <img
                       alt="Crataegus phaenopyrum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2178,7 +2167,7 @@ first three years to establish their roots.
                     <img
                       alt="Crataegus x lavallei"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2224,7 +2213,7 @@ first three years to establish their roots.
                     <img
                       alt="Elaeocarpus decipiens"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2270,7 +2259,7 @@ first three years to establish their roots.
                     <img
                       alt="Eriobotrya deflexa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2352,7 +2341,7 @@ first three years to establish their roots.
                     <img
                       alt="Eucalyptus nicholii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2398,7 +2387,7 @@ first three years to establish their roots.
                     <img
                       alt="Eucalyptus polyanthemos"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2444,7 +2433,7 @@ first three years to establish their roots.
                     <img
                       alt="Garrya elliptica"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2490,7 +2479,7 @@ first three years to establish their roots.
                     <img
                       alt="Geijera parviflora"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2572,7 +2561,7 @@ first three years to establish their roots.
                     <img
                       alt="Heteromeles arbutifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2618,7 +2607,7 @@ first three years to establish their roots.
                     <img
                       alt="Howea forsteriana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2664,7 +2653,7 @@ first three years to establish their roots.
                     <img
                       alt="Hymenosporum flavum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2710,7 +2699,7 @@ first three years to establish their roots.
                     <img
                       alt="Jacaranda mimosifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2756,7 +2745,7 @@ first three years to establish their roots.
                     <img
                       alt="Koelreuteria bipinnata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2802,7 +2791,7 @@ first three years to establish their roots.
                     <img
                       alt="Koelreuteria elegans ssp. formosana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2848,7 +2837,7 @@ first three years to establish their roots.
                     <img
                       alt="Lagunaria patersonii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2930,7 +2919,7 @@ first three years to establish their roots.
                     <img
                       alt="Liriodendron tulipifera"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -2976,7 +2965,7 @@ first three years to establish their roots.
                     <img
                       alt="Lophostemon confertus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3022,7 +3011,7 @@ first three years to establish their roots.
                     <img
                       alt="Lyonothamnus floribundus asplenifolius"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3104,7 +3093,7 @@ first three years to establish their roots.
                     <img
                       alt="Magnolia doltsopa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3258,7 +3247,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca ericifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3304,7 +3293,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca linariifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3350,7 +3339,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca quinquenervia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3396,7 +3385,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca squamophloia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3442,7 +3431,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca styphelioides"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3524,7 +3513,7 @@ first three years to establish their roots.
                     <img
                       alt="Metrosideros excelsa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3606,7 +3595,7 @@ first three years to establish their roots.
                     <img
                       alt="Olea europaea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3652,7 +3641,7 @@ first three years to establish their roots.
                     <img
                       alt="Parajubaea sunkha"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3698,7 +3687,7 @@ first three years to establish their roots.
                     <img
                       alt="Parajubaea torallyi"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -3852,7 +3841,7 @@ first three years to establish their roots.
                     <img
                       alt="Pittosporum undulatum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4006,7 +3995,7 @@ first three years to establish their roots.
                     <img
                       alt="Prunus ilicifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4052,7 +4041,7 @@ first three years to establish their roots.
                     <img
                       alt="Prunus lyonii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4134,7 +4123,7 @@ first three years to establish their roots.
                     <img
                       alt="Pyrus kawakamii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4180,7 +4169,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus agrifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4226,7 +4215,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus chyrsolepis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4272,7 +4261,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus coccinea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4318,7 +4307,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus engelmannii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4400,7 +4389,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus hypoleucoides"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4446,7 +4435,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus ilex"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4492,7 +4481,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus phellos"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4538,7 +4527,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus rugosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4584,7 +4573,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus suber"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4630,7 +4619,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus tomentella"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4676,7 +4665,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus virginiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4722,7 +4711,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus wislizeni"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4768,7 +4757,7 @@ first three years to establish their roots.
                     <img
                       alt="Quillaja saponaria"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4850,7 +4839,7 @@ first three years to establish their roots.
                     <img
                       alt="Sambucus cerulea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4896,7 +4885,7 @@ first three years to establish their roots.
                     <img
                       alt="Syagrus romanzoffiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -4942,7 +4931,7 @@ first three years to establish their roots.
                     <img
                       alt="Tilia tomentosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5024,7 +5013,7 @@ first three years to establish their roots.
                     <img
                       alt="Tristaniopsis laurina"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5250,7 +5239,7 @@ first three years to establish their roots.
                     <img
                       alt="Washingtonia robusta"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5572,39 +5561,28 @@ first three years to establish their roots.
             class="treelistcards"
           >
             <div
-              class="treelistcards__container"
+              class="treelistcards__header"
             >
-              <div
-                class="treelistcards__header"
+              <h5
+                class="treelistcards__info"
               >
-                <div
-                  class="card"
-                  data-testid="card"
-                >
-                  <div
-                    class="treelistcards__info"
-                  >
-                    <h3>
-                      We encourage you to plant medium and larger-sized trees, as they
+                We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.
-                    </h3>
-                    <div
-                      class="treecare"
-                    >
-                      <a
-                        class="treelistcards__link"
-                        href="https://www.friendsoftheurbanforest.org/tree-care"
-                        rel="noreferrer"
-                        target="_blank"
-                      >
-                        Tree Care Program
-                      </a>
-                    </div>
-                  </div>
-                </div>
-              </div>
+first three years to establish their roots. 
+                <a
+                  class="treelistcards__link"
+                  href="https://www.friendsoftheurbanforest.org/tree-care"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Learn more about tree care.
+                </a>
+              </h5>
+            </div>
+            <div
+              class="treelistcards__container"
+            >
               <a
                 class="treelistcards__link"
                 href="/tree/acer-buergerianum"
@@ -5619,7 +5597,7 @@ first three years to establish their roots.
                     <img
                       alt="Acer buergerianum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5665,7 +5643,7 @@ first three years to establish their roots.
                     <img
                       alt="Acer circinatum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5747,7 +5725,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus californica"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5793,7 +5771,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus hippocastanum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5839,7 +5817,7 @@ first three years to establish their roots.
                     <img
                       alt="Aesculus x carnea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5885,7 +5863,7 @@ first three years to establish their roots.
                     <img
                       alt="Agonis flexuosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -5967,7 +5945,7 @@ first three years to establish their roots.
                     <img
                       alt="Angophora costata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6049,7 +6027,7 @@ first three years to establish their roots.
                     <img
                       alt="Archontophoenix cunninghamiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6095,7 +6073,7 @@ first three years to establish their roots.
                     <img
                       alt="Banksia integrifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6141,7 +6119,7 @@ first three years to establish their roots.
                     <img
                       alt="Brachychiton acerifolius"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6187,7 +6165,7 @@ first three years to establish their roots.
                     <img
                       alt="Brachychiton populneus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6233,7 +6211,7 @@ first three years to establish their roots.
                     <img
                       alt="Brahea clara"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6279,7 +6257,7 @@ first three years to establish their roots.
                     <img
                       alt="Brahea edulis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6325,7 +6303,7 @@ first three years to establish their roots.
                     <img
                       alt="Butia odorata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6371,7 +6349,7 @@ first three years to establish their roots.
                     <img
                       alt="Callistemon citrinus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6417,7 +6395,7 @@ first three years to establish their roots.
                     <img
                       alt="Callistemon viminalis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6463,7 +6441,7 @@ first three years to establish their roots.
                     <img
                       alt="Cassia leptophylla"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6581,7 +6559,7 @@ first three years to establish their roots.
                     <img
                       alt="Ceanothus thyrsiflorus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6627,7 +6605,7 @@ first three years to establish their roots.
                     <img
                       alt="Cedrela fissilis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6673,7 +6651,7 @@ first three years to establish their roots.
                     <img
                       alt="Ceiba speciosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6719,7 +6697,7 @@ first three years to establish their roots.
                     <img
                       alt="Celtis sinensis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6765,7 +6743,7 @@ first three years to establish their roots.
                     <img
                       alt="Cordyline australis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6811,7 +6789,7 @@ first three years to establish their roots.
                     <img
                       alt="Corylus colurna"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6857,7 +6835,7 @@ first three years to establish their roots.
                     <img
                       alt="Corymbia citriodora"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6903,7 +6881,7 @@ first three years to establish their roots.
                     <img
                       alt="Corymbia ficifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -6985,7 +6963,7 @@ first three years to establish their roots.
                     <img
                       alt="Crataegus phaenopyrum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7031,7 +7009,7 @@ first three years to establish their roots.
                     <img
                       alt="Crataegus x lavallei"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7077,7 +7055,7 @@ first three years to establish their roots.
                     <img
                       alt="Elaeocarpus decipiens"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7123,7 +7101,7 @@ first three years to establish their roots.
                     <img
                       alt="Eriobotrya deflexa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7205,7 +7183,7 @@ first three years to establish their roots.
                     <img
                       alt="Eucalyptus nicholii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7251,7 +7229,7 @@ first three years to establish their roots.
                     <img
                       alt="Eucalyptus polyanthemos"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7297,7 +7275,7 @@ first three years to establish their roots.
                     <img
                       alt="Garrya elliptica"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7343,7 +7321,7 @@ first three years to establish their roots.
                     <img
                       alt="Geijera parviflora"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7425,7 +7403,7 @@ first three years to establish their roots.
                     <img
                       alt="Heteromeles arbutifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7471,7 +7449,7 @@ first three years to establish their roots.
                     <img
                       alt="Howea forsteriana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7517,7 +7495,7 @@ first three years to establish their roots.
                     <img
                       alt="Hymenosporum flavum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7563,7 +7541,7 @@ first three years to establish their roots.
                     <img
                       alt="Jacaranda mimosifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7609,7 +7587,7 @@ first three years to establish their roots.
                     <img
                       alt="Koelreuteria bipinnata"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7655,7 +7633,7 @@ first three years to establish their roots.
                     <img
                       alt="Koelreuteria elegans ssp. formosana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7701,7 +7679,7 @@ first three years to establish their roots.
                     <img
                       alt="Lagunaria patersonii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7783,7 +7761,7 @@ first three years to establish their roots.
                     <img
                       alt="Liriodendron tulipifera"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7829,7 +7807,7 @@ first three years to establish their roots.
                     <img
                       alt="Lophostemon confertus"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7875,7 +7853,7 @@ first three years to establish their roots.
                     <img
                       alt="Lyonothamnus floribundus asplenifolius"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -7957,7 +7935,7 @@ first three years to establish their roots.
                     <img
                       alt="Magnolia doltsopa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8111,7 +8089,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca ericifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8157,7 +8135,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca linariifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8203,7 +8181,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca quinquenervia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8249,7 +8227,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca squamophloia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8295,7 +8273,7 @@ first three years to establish their roots.
                     <img
                       alt="Melaleuca styphelioides"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8377,7 +8355,7 @@ first three years to establish their roots.
                     <img
                       alt="Metrosideros excelsa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8459,7 +8437,7 @@ first three years to establish their roots.
                     <img
                       alt="Olea europaea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8505,7 +8483,7 @@ first three years to establish their roots.
                     <img
                       alt="Parajubaea sunkha"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8551,7 +8529,7 @@ first three years to establish their roots.
                     <img
                       alt="Parajubaea torallyi"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8705,7 +8683,7 @@ first three years to establish their roots.
                     <img
                       alt="Pittosporum undulatum"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8859,7 +8837,7 @@ first three years to establish their roots.
                     <img
                       alt="Prunus ilicifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8905,7 +8883,7 @@ first three years to establish their roots.
                     <img
                       alt="Prunus lyonii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -8987,7 +8965,7 @@ first three years to establish their roots.
                     <img
                       alt="Pyrus kawakamii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9033,7 +9011,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus agrifolia"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9079,7 +9057,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus chyrsolepis"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9125,7 +9103,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus coccinea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9171,7 +9149,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus engelmannii"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9253,7 +9231,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus hypoleucoides"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9299,7 +9277,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus ilex"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9345,7 +9323,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus phellos"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9391,7 +9369,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus rugosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9437,7 +9415,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus suber"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9483,7 +9461,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus tomentella"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9529,7 +9507,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus virginiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9575,7 +9553,7 @@ first three years to establish their roots.
                     <img
                       alt="Quercus wislizeni"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9621,7 +9599,7 @@ first three years to establish their roots.
                     <img
                       alt="Quillaja saponaria"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9703,7 +9681,7 @@ first three years to establish their roots.
                     <img
                       alt="Sambucus cerulea"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9749,7 +9727,7 @@ first three years to establish their roots.
                     <img
                       alt="Syagrus romanzoffiana"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9795,7 +9773,7 @@ first three years to establish their roots.
                     <img
                       alt="Tilia tomentosa"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -9877,7 +9855,7 @@ first three years to establish their roots.
                     <img
                       alt="Tristaniopsis laurina"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -10103,7 +10081,7 @@ first three years to establish their roots.
                     <img
                       alt="Washingtonia robusta"
                       loading="lazy"
-                      placeholder="./../assets/images/treelist/placeholder.jpg"
+                      placeholder="./../assets/images/treelist/placeholder.svg"
                       style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                     />
                   </div>
@@ -10876,39 +10854,28 @@ label[data-shrink=false]+.MuiInputBase-formControl .emotion-3:focus::-ms-input-p
           class="treelistcards"
         >
           <div
-            class="treelistcards__container"
+            class="treelistcards__header"
           >
-            <div
-              class="treelistcards__header"
+            <h5
+              class="treelistcards__info"
             >
-              <div
-                class="card"
-                data-testid="card"
-              >
-                <div
-                  class="treelistcards__info"
-                >
-                  <h3>
-                    We encourage you to plant medium and larger-sized trees, as they
+              We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.
-                  </h3>
-                  <div
-                    class="treecare"
-                  >
-                    <a
-                      class="treelistcards__link"
-                      href="https://www.friendsoftheurbanforest.org/tree-care"
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      Tree Care Program
-                    </a>
-                  </div>
-                </div>
-              </div>
-            </div>
+first three years to establish their roots. 
+              <a
+                class="treelistcards__link"
+                href="https://www.friendsoftheurbanforest.org/tree-care"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Learn more about tree care.
+              </a>
+            </h5>
+          </div>
+          <div
+            class="treelistcards__container"
+          >
             <a
               class="treelistcards__link"
               href="/tree/acer-buergerianum"
@@ -10923,7 +10890,7 @@ first three years to establish their roots.
                   <img
                     alt="Acer buergerianum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -10969,7 +10936,7 @@ first three years to establish their roots.
                   <img
                     alt="Acer circinatum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11051,7 +11018,7 @@ first three years to establish their roots.
                   <img
                     alt="Aesculus californica"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11097,7 +11064,7 @@ first three years to establish their roots.
                   <img
                     alt="Aesculus hippocastanum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11143,7 +11110,7 @@ first three years to establish their roots.
                   <img
                     alt="Aesculus x carnea"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11189,7 +11156,7 @@ first three years to establish their roots.
                   <img
                     alt="Agonis flexuosa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11271,7 +11238,7 @@ first three years to establish their roots.
                   <img
                     alt="Angophora costata"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11353,7 +11320,7 @@ first three years to establish their roots.
                   <img
                     alt="Archontophoenix cunninghamiana"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11399,7 +11366,7 @@ first three years to establish their roots.
                   <img
                     alt="Banksia integrifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11445,7 +11412,7 @@ first three years to establish their roots.
                   <img
                     alt="Brachychiton acerifolius"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11491,7 +11458,7 @@ first three years to establish their roots.
                   <img
                     alt="Brachychiton populneus"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11537,7 +11504,7 @@ first three years to establish their roots.
                   <img
                     alt="Brahea clara"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11583,7 +11550,7 @@ first three years to establish their roots.
                   <img
                     alt="Brahea edulis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11629,7 +11596,7 @@ first three years to establish their roots.
                   <img
                     alt="Butia odorata"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11675,7 +11642,7 @@ first three years to establish their roots.
                   <img
                     alt="Callistemon citrinus"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11721,7 +11688,7 @@ first three years to establish their roots.
                   <img
                     alt="Callistemon viminalis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11767,7 +11734,7 @@ first three years to establish their roots.
                   <img
                     alt="Cassia leptophylla"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11885,7 +11852,7 @@ first three years to establish their roots.
                   <img
                     alt="Ceanothus thyrsiflorus"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11931,7 +11898,7 @@ first three years to establish their roots.
                   <img
                     alt="Cedrela fissilis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -11977,7 +11944,7 @@ first three years to establish their roots.
                   <img
                     alt="Ceiba speciosa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12023,7 +11990,7 @@ first three years to establish their roots.
                   <img
                     alt="Celtis sinensis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12069,7 +12036,7 @@ first three years to establish their roots.
                   <img
                     alt="Cordyline australis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12115,7 +12082,7 @@ first three years to establish their roots.
                   <img
                     alt="Corylus colurna"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12161,7 +12128,7 @@ first three years to establish their roots.
                   <img
                     alt="Corymbia citriodora"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12207,7 +12174,7 @@ first three years to establish their roots.
                   <img
                     alt="Corymbia ficifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12289,7 +12256,7 @@ first three years to establish their roots.
                   <img
                     alt="Crataegus phaenopyrum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12335,7 +12302,7 @@ first three years to establish their roots.
                   <img
                     alt="Crataegus x lavallei"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12381,7 +12348,7 @@ first three years to establish their roots.
                   <img
                     alt="Elaeocarpus decipiens"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12427,7 +12394,7 @@ first three years to establish their roots.
                   <img
                     alt="Eriobotrya deflexa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12509,7 +12476,7 @@ first three years to establish their roots.
                   <img
                     alt="Eucalyptus nicholii"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12555,7 +12522,7 @@ first three years to establish their roots.
                   <img
                     alt="Eucalyptus polyanthemos"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12601,7 +12568,7 @@ first three years to establish their roots.
                   <img
                     alt="Garrya elliptica"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12647,7 +12614,7 @@ first three years to establish their roots.
                   <img
                     alt="Geijera parviflora"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12729,7 +12696,7 @@ first three years to establish their roots.
                   <img
                     alt="Heteromeles arbutifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12775,7 +12742,7 @@ first three years to establish their roots.
                   <img
                     alt="Howea forsteriana"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12821,7 +12788,7 @@ first three years to establish their roots.
                   <img
                     alt="Hymenosporum flavum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12867,7 +12834,7 @@ first three years to establish their roots.
                   <img
                     alt="Jacaranda mimosifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12913,7 +12880,7 @@ first three years to establish their roots.
                   <img
                     alt="Koelreuteria bipinnata"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -12959,7 +12926,7 @@ first three years to establish their roots.
                   <img
                     alt="Koelreuteria elegans ssp. formosana"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13005,7 +12972,7 @@ first three years to establish their roots.
                   <img
                     alt="Lagunaria patersonii"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13087,7 +13054,7 @@ first three years to establish their roots.
                   <img
                     alt="Liriodendron tulipifera"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13133,7 +13100,7 @@ first three years to establish their roots.
                   <img
                     alt="Lophostemon confertus"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13179,7 +13146,7 @@ first three years to establish their roots.
                   <img
                     alt="Lyonothamnus floribundus asplenifolius"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13261,7 +13228,7 @@ first three years to establish their roots.
                   <img
                     alt="Magnolia doltsopa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13415,7 +13382,7 @@ first three years to establish their roots.
                   <img
                     alt="Melaleuca ericifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13461,7 +13428,7 @@ first three years to establish their roots.
                   <img
                     alt="Melaleuca linariifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13507,7 +13474,7 @@ first three years to establish their roots.
                   <img
                     alt="Melaleuca quinquenervia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13553,7 +13520,7 @@ first three years to establish their roots.
                   <img
                     alt="Melaleuca squamophloia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13599,7 +13566,7 @@ first three years to establish their roots.
                   <img
                     alt="Melaleuca styphelioides"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13681,7 +13648,7 @@ first three years to establish their roots.
                   <img
                     alt="Metrosideros excelsa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13763,7 +13730,7 @@ first three years to establish their roots.
                   <img
                     alt="Olea europaea"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13809,7 +13776,7 @@ first three years to establish their roots.
                   <img
                     alt="Parajubaea sunkha"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -13855,7 +13822,7 @@ first three years to establish their roots.
                   <img
                     alt="Parajubaea torallyi"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14009,7 +13976,7 @@ first three years to establish their roots.
                   <img
                     alt="Pittosporum undulatum"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14163,7 +14130,7 @@ first three years to establish their roots.
                   <img
                     alt="Prunus ilicifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14209,7 +14176,7 @@ first three years to establish their roots.
                   <img
                     alt="Prunus lyonii"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14291,7 +14258,7 @@ first three years to establish their roots.
                   <img
                     alt="Pyrus kawakamii"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14337,7 +14304,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus agrifolia"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14383,7 +14350,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus chyrsolepis"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14429,7 +14396,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus coccinea"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14475,7 +14442,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus engelmannii"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14557,7 +14524,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus hypoleucoides"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14603,7 +14570,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus ilex"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14649,7 +14616,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus phellos"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14695,7 +14662,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus rugosa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14741,7 +14708,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus suber"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14787,7 +14754,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus tomentella"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14833,7 +14800,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus virginiana"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14879,7 +14846,7 @@ first three years to establish their roots.
                   <img
                     alt="Quercus wislizeni"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -14925,7 +14892,7 @@ first three years to establish their roots.
                   <img
                     alt="Quillaja saponaria"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15007,7 +14974,7 @@ first three years to establish their roots.
                   <img
                     alt="Sambucus cerulea"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15053,7 +15020,7 @@ first three years to establish their roots.
                   <img
                     alt="Syagrus romanzoffiana"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15099,7 +15066,7 @@ first three years to establish their roots.
                   <img
                     alt="Tilia tomentosa"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15181,7 +15148,7 @@ first three years to establish their roots.
                   <img
                     alt="Tristaniopsis laurina"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>
@@ -15407,7 +15374,7 @@ first three years to establish their roots.
                   <img
                     alt="Washingtonia robusta"
                     loading="lazy"
-                    placeholder="./../assets/images/treelist/placeholder.jpg"
+                    placeholder="./../assets/images/treelist/placeholder.svg"
                     style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                   />
                 </div>

--- a/client/src/tests/__snapshots__/TreeListCards.test.js.snap
+++ b/client/src/tests/__snapshots__/TreeListCards.test.js.snap
@@ -9,39 +9,28 @@ exports[`TreeListCards component renders TreeListCards correctly 1`] = `
         class="treelistcards"
       >
         <div
-          class="treelistcards__container"
+          class="treelistcards__header"
         >
-          <div
-            class="treelistcards__header"
+          <h5
+            class="treelistcards__info"
           >
-            <div
-              class="card"
-              data-testid="card"
-            >
-              <div
-                class="treelistcards__info"
-              >
-                <h3>
-                  We encourage you to plant medium and larger-sized trees, as they
+            We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.
-                </h3>
-                <div
-                  class="treecare"
-                >
-                  <a
-                    class="treelistcards__link"
-                    href="https://vimeo.com/416031708#t=5m35s"
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    Tree Care Program
-                  </a>
-                </div>
-              </div>
-            </div>
-          </div>
+first three years to establish their roots. 
+            <a
+              class="treelistcards__link"
+              href="/treecare"
+              rel="noopener noreferrer"
+              target="_self"
+            >
+              Learn more about tree care.
+            </a>
+          </h5>
+        </div>
+        <div
+          class="treelistcards__container"
+        >
           <a
             class="treelistcards__link"
             href="/tree/sequoia-sempervirens-'adpressa'"
@@ -56,7 +45,7 @@ first three years to establish their roots.
                 <img
                   alt="Sequoia sempervirens 'Adpressa'"
                   loading="lazy"
-                  placeholder="./../assets/images/treelist/placeholder.jpg"
+                  placeholder="./../assets/images/treelist/placeholder.svg"
                   style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                 />
               </div>
@@ -102,7 +91,7 @@ first three years to establish their roots.
                 <img
                   alt="Callitropsis nootkatensis"
                   loading="lazy"
-                  placeholder="./../assets/images/treelist/placeholder.jpg"
+                  placeholder="./../assets/images/treelist/placeholder.svg"
                   style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                 />
               </div>
@@ -143,39 +132,28 @@ first three years to establish their roots.
       class="treelistcards"
     >
       <div
-        class="treelistcards__container"
+        class="treelistcards__header"
       >
-        <div
-          class="treelistcards__header"
+        <h5
+          class="treelistcards__info"
         >
-          <div
-            class="card"
-            data-testid="card"
-          >
-            <div
-              class="treelistcards__info"
-            >
-              <h3>
-                We encourage you to plant medium and larger-sized trees, as they
+          We encourage you to plant medium and larger-sized trees, as they
 provide greater benefits to the city than smaller trees. Young trees
 require 1.5 inches of rain or 25 gallons of water per week for the
-first three years to establish their roots.
-              </h3>
-              <div
-                class="treecare"
-              >
-                <a
-                  class="treelistcards__link"
-                  href="https://vimeo.com/416031708#t=5m35s"
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  Tree Care Program
-                </a>
-              </div>
-            </div>
-          </div>
-        </div>
+first three years to establish their roots. 
+          <a
+            class="treelistcards__link"
+            href="/treecare"
+            rel="noopener noreferrer"
+            target="_self"
+          >
+            Learn more about tree care.
+          </a>
+        </h5>
+      </div>
+      <div
+        class="treelistcards__container"
+      >
         <a
           class="treelistcards__link"
           href="/tree/sequoia-sempervirens-'adpressa'"
@@ -190,7 +168,7 @@ first three years to establish their roots.
               <img
                 alt="Sequoia sempervirens 'Adpressa'"
                 loading="lazy"
-                placeholder="./../assets/images/treelist/placeholder.jpg"
+                placeholder="./../assets/images/treelist/placeholder.svg"
                 style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
               />
             </div>
@@ -236,7 +214,7 @@ first three years to establish their roots.
               <img
                 alt="Callitropsis nootkatensis"
                 loading="lazy"
-                placeholder="./../assets/images/treelist/placeholder.jpg"
+                placeholder="./../assets/images/treelist/placeholder.svg"
                 style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
               />
             </div>

--- a/client/src/tests/__snapshots__/TreeListCards.test.js.snap
+++ b/client/src/tests/__snapshots__/TreeListCards.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<TreeListCards /> spec renders TreeListCards correctly 1`] = `
+exports[`TreeListCards component renders TreeListCards correctly 1`] = `
 {
   "asFragment": [Function],
   "baseElement": <body>
@@ -54,10 +54,9 @@ first three years to establish their roots.
                 class="treelistcards__image"
               >
                 <img
-                  alt=""
+                  alt="Sequoia sempervirens 'Adpressa'"
                   loading="lazy"
-                  placeholder="placeholder.jpg"
-                  src="placeholder.jpg"
+                  placeholder="./../assets/images/treelist/placeholder.jpg"
                   style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                 />
               </div>
@@ -101,10 +100,9 @@ first three years to establish their roots.
                 class="treelistcards__image"
               >
                 <img
-                  alt=""
+                  alt="Callitropsis nootkatensis"
                   loading="lazy"
-                  placeholder="placeholder.jpg"
-                  src="placeholder.jpg"
+                  placeholder="./../assets/images/treelist/placeholder.jpg"
                   style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
                 />
               </div>
@@ -190,10 +188,9 @@ first three years to establish their roots.
               class="treelistcards__image"
             >
               <img
-                alt=""
+                alt="Sequoia sempervirens 'Adpressa'"
                 loading="lazy"
-                placeholder="placeholder.jpg"
-                src="placeholder.jpg"
+                placeholder="./../assets/images/treelist/placeholder.jpg"
                 style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
               />
             </div>
@@ -237,10 +234,9 @@ first three years to establish their roots.
               class="treelistcards__image"
             >
               <img
-                alt=""
+                alt="Callitropsis nootkatensis"
                 loading="lazy"
-                placeholder="placeholder.jpg"
-                src="placeholder.jpg"
+                placeholder="./../assets/images/treelist/placeholder.jpg"
                 style="opacity: 0.1; transition: opacity .30s linear; width: 100%;"
               />
             </div>

--- a/data/build.js
+++ b/data/build.js
@@ -193,6 +193,7 @@ async function buildScientificNameToImageMap(names) {
     const MAX_TITLES_PER_QUERY = 50;
     const partitions = partition(data, MAX_TITLES_PER_QUERY);
     const queryTitles = partitions.map((titles) => titles.join('|'));
+    console.log(queryTitles, queryTitles, queryTitles.length);
     const queries = queryTitles.map((titles) => buildRequestURL(titles));
     return queries.map((query) => query.href);
   }

--- a/data/build.js
+++ b/data/build.js
@@ -331,13 +331,19 @@ async function downloadImage(imageURL, title) {
     const dataDir = './client/src/assets/images/data';
     if (!fs.existsSync(dataDir)) {
       fs.mkdirSync(dataDir, { recursive: true });
+      console.info(`Created directory: ${dataDir}`);
     }
 
     const imageName = `${formatWord(title)}.jpg`;
-    const buffer = await response.arrayBuffer();
-    fs.writeFileSync(`${dataDir}/${imageName}`, Buffer.from(buffer));
+    const imagePath = `${dataDir}/${imageName}`;
+    if (!fs.existsSync(imagePath)) {
+      const buffer = await response.arrayBuffer();
+      fs.writeFileSync(imagePath, Buffer.from(buffer));
+      console.info(`Downloaded and saved new image: ${imageName}`);
+    } else {
+      console.info(`Image already exists: ${imageName}`);
+    }
 
-    console.info(`Downloaded and saved image: ${imageName}`);
     return imageName;
   } catch (error) {
     console.error(`Error downloading ${imageURL} - ${error.message}`);


### PR DESCRIPTION
Images were not showing up on the dev server due to capitalization differences between mac and linux and the image copy plugin. Webpack was having a race condition and crashing part way through the build due to this issue.