### PR TITLE
User Profile Redesign - refactor to eliminate styled components

### DIFF
--- a/client/src/pages/Userprofile/UserInfoContainer.js
+++ b/client/src/pages/Userprofile/UserInfoContainer.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Avatar, Box, Typography } from '@mui/material';
-import { styled } from '@mui/material/styles';
 import { Star } from '@mui/icons-material';
 import TreeIcon from '@/assets/images/addtree/tree12.svg';
 import AdoptionIcon from '@/components/Icons/AdoptionIcon/AdoptionIcon';

--- a/client/src/pages/Userprofile/UserInfoContainer.js
+++ b/client/src/pages/Userprofile/UserInfoContainer.js
@@ -7,12 +7,6 @@ import AdoptionIcon from '@/components/Icons/AdoptionIcon/AdoptionIcon';
 import { TooltipBottom } from '@/components/Tooltip';
 import './UserInfoContainer.scss';
 
-const UserAvatar = styled(Avatar)`
-  width: 8em;
-  height: 8em;
-  margin: 0 3em 0 2em;
-`;
-
 const iconStyle = {
   height: '2em',
   width: '2em',
@@ -63,7 +57,7 @@ const UserInfoContainer = ({ adoptedTrees, likedTrees, plantedTrees, user }) => 
   const { name, nickname, email, picture } = user;
   return (
     <div className="user-info-container">
-      <UserAvatar alt="Avatar" src={picture} />
+      <Avatar className="user-avatar" alt="Avatar" src={picture} />
       <div>
         <UserIcons
           adoptedCount={adoptedTrees.length}

--- a/client/src/pages/Userprofile/UserInfoContainer.js
+++ b/client/src/pages/Userprofile/UserInfoContainer.js
@@ -5,12 +5,7 @@ import { Star } from '@mui/icons-material';
 import TreeIcon from '@/assets/images/addtree/tree12.svg';
 import AdoptionIcon from '@/components/Icons/AdoptionIcon/AdoptionIcon';
 import { TooltipBottom } from '@/components/Tooltip';
-
-const UserInfoContainerBox = styled(Box)`
-  display: inline-flex;
-  align-items: center;
-  margin-bottom: 2em;
-`;
+import './UserInfoContainer.scss';
 
 const UserAvatar = styled(Avatar)`
   width: 8em;
@@ -67,7 +62,7 @@ const UserIcons = ({ adoptedCount, likedCount, plantedCount }) => (
 const UserInfoContainer = ({ adoptedTrees, likedTrees, plantedTrees, user }) => {
   const { name, nickname, email, picture } = user;
   return (
-    <UserInfoContainerBox>
+    <div className="user-info-container">
       <UserAvatar alt="Avatar" src={picture} />
       <div>
         <UserIcons
@@ -79,7 +74,7 @@ const UserInfoContainer = ({ adoptedTrees, likedTrees, plantedTrees, user }) => 
         <Typography variant="body1">{nickname}</Typography>
         <Typography variant="body1">{email}</Typography>
       </div>
-    </UserInfoContainerBox>
+    </div>
   )
 }
 export default UserInfoContainer

--- a/client/src/pages/Userprofile/UserInfoContainer.scss
+++ b/client/src/pages/Userprofile/UserInfoContainer.scss
@@ -2,4 +2,10 @@
   display: inline-flex;
   align-items: center;
   margin-bottom: 2em;
+
+  .user-avatar {
+    width: 8em;
+    height: 8em;
+    margin: 0 3em 0 2em;
+  }
 }

--- a/client/src/pages/Userprofile/UserInfoContainer.scss
+++ b/client/src/pages/Userprofile/UserInfoContainer.scss
@@ -1,0 +1,5 @@
+.user-info-container {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 2em;
+}


### PR DESCRIPTION
**ISSUE:**
https://github.com/waterthetrees/wtt_front/issues/635

**REASON:**
Currently, the `UserInfoContainer` component is using styled components, which we want to phase out.  

I've removed the styled components `UserInfoContainerBox` and `UserAvatar`, and replaced them with custom classes in a new CSS file `UserInfoContainer.scss` .

This is refactoring under the hood and should not affect the UX/UI in the browser in any way.