### PR TITLE
adds back the tree maintenance profile view post maintenance form submit

### DIFF
--- a/client/src/pages/Tree/Tree.js
+++ b/client/src/pages/Tree/Tree.js
@@ -65,7 +65,7 @@ export default function Tree({
     setTimeout(() => {
       setMaintenanceAlert(null);
       setMaintenanceAlertVisible(false);
-    }, 10000);
+    }, 6000);
   }
 
   const closeMaintenanceAlert = () => {
@@ -112,7 +112,6 @@ export default function Tree({
               <TreeMaintenance
                 currentTreeData={currentTreeData}
                 isTreeQueryError={isTreeQueryError}
-                closeTreeDetails={handleClose}
                 maintenanceAlert={handleMaintenanceAlert}
                 closeMaintenanceAlert={closeMaintenanceAlert}
               />

--- a/client/src/pages/Tree/TreeMaintenance.js
+++ b/client/src/pages/Tree/TreeMaintenance.js
@@ -11,7 +11,7 @@ import useAuthUtils from '@/components/Auth/useAuthUtils';
 import TreeMaintenanceSidebar from './TreeMaintenanceSidebar';
 import './TreeMaintenance.scss';
 
-export default function TreeMaintenance({ currentTreeData, isTreeQueryError, closeTreeDetails, maintenanceAlert, closeMaintenanceAlert }) {
+export default function TreeMaintenance({ currentTreeData, isTreeQueryError, maintenanceAlert, closeMaintenanceAlert }) {
   const { id } = currentTreeData;
   const { user = {}, isAuthenticated } = useAuth0();
   const { loginToCurrentPage } = useAuthUtils();
@@ -55,7 +55,6 @@ export default function TreeMaintenance({ currentTreeData, isTreeQueryError, clo
 
   const handleConfirm = ({ actions, volunteer, comment }) => {
     closeMaintenanceSidebar();
-    closeTreeDetails()
     MaintenanceSubmitNotification("success", "Thank you for submitting a maintenance request!")
 
     if (comment || Object.keys(actions).length) {

--- a/client/src/pages/Tree/TreeMaintenance.scss
+++ b/client/src/pages/Tree/TreeMaintenance.scss
@@ -11,6 +11,7 @@
   place-items: center;
   width: 100%;
   height: 0px;
+  z-index: 1000000;
 }
 
 .alert-success {


### PR DESCRIPTION
Adding back the tree view after submit maintenance request. Previous PR (https://github.com/waterthetrees/wtt_front/pull/782) brought you back to the map however we want the tree profile view to persist after filling out the maintenance form. 
## Desktop view
<img width="1440" alt="Screenshot 2023-12-07 at 5 41 58 PM" src="https://github.com/waterthetrees/wtt_front/assets/8885849/5bd7b61c-2577-4d86-9f2d-52ada60d57a9">

## Mobile view
<img width="531" alt="Screenshot 2023-12-07 at 5 42 43 PM" src="https://github.com/waterthetrees/wtt_front/assets/8885849/405f6f35-82dc-4f86-86ea-59f1a10f2b31">
